### PR TITLE
Toc in parent

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 A JupyterLab server extension that provides Jupyter-Book navigation via a sidepanel widget holding a Jupyter-Book table of contents.
 
 > [!WARNING]
-> This package is currently in a pre-alpha stage. Please be aware of the following:
-> 1. **Expect Significant Changes:** The software is still under heavy development. Features, functionality, and the overall design may change significantly in future updates.
-> 1. **Limited Functionality and Correctness:** There are no guarantees of full functionality or correctness. The software may contain bugs and incomplete features.
+> This package is currently in a pre-alpha stage:
+> 1. **Expect Significant Changes:** Features, functionality, and the overall design may change significantly in future updates.
+> 1. **Limited Functionality and Correctness:** There are no guarantees of full functionality or correctness.
 > 1. **Use at Your Own Risk:** Given its early stage of development, users should exercise caution when integrating this package into critical systems.
 
 This extension is composed of a Python package named `jupyterlab_jupyterbook_navigation`

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A JupyterLab server extension that provides Jupyter-Book navigation via a sidepa
 
 > [!WARNING]
 > This package is currently in a pre-alpha stage:
+>
 > 1. **Expect Significant Changes:** Features, functionality, and the overall design may change significantly in future updates.
 > 1. **Limited Functionality and Correctness:** There are no guarantees of full functionality or correctness.
 > 1. **Use at Your Own Risk:** Given its early stage of development, users should exercise caution when integrating this package into critical systems.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 A JupyterLab server extension that provides Jupyter-Book navigation via a sidepanel widget holding a Jupyter-Book table of contents.
 
+> [!WARNING]
+> This package is currently in a pre-alpha stage. Please be aware of the following:
+> 1. **Expect Significant Changes:** The software is still under heavy development. Features, functionality, and the overall design may change significantly in future updates.
+> 1. **Limited Functionality and Correctness:** There are no guarantees of full functionality or correctness. The software may contain bugs and incomplete features.
+> 1. **Use at Your Own Risk:** Given its early stage of development, users should exercise caution when integrating this package into critical systems.
+
 This extension is composed of a Python package named `jupyterlab_jupyterbook_navigation`
 for the server extension and a NPM package named `jupyterlab-jupyterbook-navigation`
 for the frontend extension.

--- a/jupyterlab_jupyterbook_navigation/jbook_toc.py
+++ b/jupyterlab_jupyterbook_navigation/jbook_toc.py
@@ -107,13 +107,15 @@ def toc_to_html(toc, cwd):
 def find_toc_in_parents(cwd):
     current_dir = Path(cwd)
     toc_pattern = "_toc.yml"
-    while True:
+    depth = 0  # prevent an endless loop in environments where Path.home() behaves in unexpected ways
+    while depth < 20:
         toc_pth = list(current_dir.glob(toc_pattern))
         if toc_pth and len(toc_pth) == 1:
             return toc_pth[0]
         if current_dir == Path.home():
             break
         current_dir = current_dir.parent
+        depth += 1
     return None
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-jupyterbook-navigation",
-    "version": "0.1.0",
+    "version": "0.1.2",
     "description": "A JupyterLab extension that mimics jupyter-book chapter navigation on an un-built, cloned jupyter book in JupyterLab.",
     "keywords": [
         "jupyter",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-jupyterbook-navigation",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "description": "A JupyterLab extension that mimics jupyter-book chapter navigation on an un-built, cloned jupyter book in JupyterLab.",
     "keywords": [
         "jupyter",

--- a/style/index.css
+++ b/style/index.css
@@ -15,6 +15,10 @@
   padding-left: 6px;
 }
 
+.toc-link {
+  color: var(--jp-content-link-color);
+}
+
 .jp-Button.toc-chevron:hover {
   color: var(--jp-layout-color3);
 }


### PR DESCRIPTION
- Add pre-alpha warning
- Use jupyter link styling for table of contents links
- Support _toc.yml without 'parts'
- View and use table of contents from any subdirectory within a Jupyter-Book