### PR TITLE
update css for JupyterLab>=4.3.0 to fix Jupyter Book icon display

### DIFF
--- a/style/index.css
+++ b/style/index.css
@@ -43,7 +43,7 @@
   background-image: url('jbook_icon.svg');
 }
 
-.jbook-icon svg g path {
+.jbook-icon svg path {
   display: none;
 }
 


### PR DESCRIPTION
Fixes #25 

- do not display any `.jbook-icon` svg paths. Previously only those in the `g` group were hidden.