### PR TITLE
Bug: Fix JBook icon display issue and incorrect tab level in dropdown subsections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ previous version: 0.1.4
 
 - Move TOC logic client side
 
+## Version 1.0.1
+
+- Fixes #25
+- Fixes #26
+
 <!-- <START NEW CHANGELOG ENTRY> -->
 
 ## Version 1.0.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-jupyterbook-navigation",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "A JupyterLab extension that mimics jupyter-book chapter navigation on an un-built, cloned jupyter book in JupyterLab.",
     "keywords": [
         "jupyter",

--- a/src/jbtoc.ts
+++ b/src/jbtoc.ts
@@ -248,6 +248,7 @@ async function getSubSection(
         (level = level + 1),
         (html = html_cur)
       );
+      level = level - 1;
       html += '</div>';
     } else if (k.file) {
       await insert_one_file(k.file);
@@ -278,7 +279,6 @@ async function tocToHtml(toc: IToc, cwd: string): Promise<string> {
       html += `\n${subISectionHtml}`;
     }
   }
-
   html += '\n</ul>';
   return html;
 }

--- a/style/index.css
+++ b/style/index.css
@@ -43,7 +43,7 @@
   background-image: url('jbook_icon.svg');
 }
 
-.jbook-icon svg g path {
+.jbook-icon svg path {
   display: none;
 }
 


### PR DESCRIPTION
- Fixes #25
  - Do not display any .jbook-icon svg paths. Previously only those in the g group were hidden.
  - Issue emerged in JupyterLab v4.3.0
    - The fix is backward-compatible
- Fixes #26 
  - Reset tab level to the previous state after exiting a dropdown subsection
- Bump version to 1.0.1
- Update CHANGELOG.md 
