### PR TITLE
bump version to 1.0.2 due to v1.0.1 release mishap 

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -24,7 +24,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Distributions
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jupyterlab_jupyterbook_navigation-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-jupyterbook-navigation",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "A JupyterLab extension that mimics jupyter-book chapter navigation on an un-built, cloned jupyter book in JupyterLab.",
     "keywords": [
         "jupyter",


### PR DESCRIPTION
v1.0.0 code was accidentally pushed to PyPi and npm packaged as v1.0.1. There is no difference between those two versions. Version 1.0.2 contains the intended v1.0.1 updates and is now live on PyPi and npm. This PR bumps the version and changes no code. 