### PR TITLE
Feature/publish release

### DIFF
--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -22,6 +22,7 @@ on:
 jobs:
   prep_release:
     runs-on: ubuntu-latest
+    environment: publishing
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
@@ -29,7 +30,7 @@ jobs:
         id: prep-release
         uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.PUBLISH_GITHUB_PAT }}
           version_spec: ${{ github.event.inputs.version_spec }}
           post_version_spec: ${{ github.event.inputs.post_version_spec }}
           branch: ${{ github.event.inputs.branch }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -27,7 +27,7 @@ jobs:
         id: populate-release
         uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.PUBLISH_GITHUB_PAT }}
           branch: ${{ github.event.inputs.branch }}
           release_url: ${{ github.event.inputs.release_url }}
           steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
@@ -43,7 +43,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@v2
         with:
-          token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
+          token: ${{ secrets.PUBLISH_GITHUB_PAT }}
           release_url: ${{ steps.populate-release.outputs.release_url }}
 
       - name: Publish to PyPI with OIDC

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   publish_release:
     runs-on: ubuntu-latest
+    environment: publishing
     permissions:
       # This is useful if you want to use PyPI trusted publisher
       # and NPM provenance
@@ -31,18 +32,22 @@ jobs:
           release_url: ${{ github.event.inputs.release_url }}
           steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
 
+      - name: Download built extension package
+        uses: actions/download-artifact@v4
+        with:
+          name: extension-artifacts 
+
       - name: Finalize Release
         id: finalize-release
         env:
-          # The following are needed if you use legacy PyPI set up
-          # PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-          # PYPI_TOKEN_MAP: ${{ secrets.PYPI_TOKEN_MAP }}
-          # TWINE_USERNAME: __token__
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         uses: jupyter-server/jupyter_releaser/.github/actions/finalize-release@v2
         with:
           token: ${{ secrets.ADMIN_GITHUB_TOKEN }}
           release_url: ${{ steps.populate-release.outputs.release_url }}
+
+      - name: Publish to PyPI with OIDC
+        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: "** Next Step **"
         if: ${{ success() }}
@@ -55,3 +60,4 @@ jobs:
         run: |
           echo "Failed to Publish the Draft Release Url:"
           echo ${{ steps.populate-release.outputs.release_url }}
+          

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ NPM frontend extension: `jupyterlab-jupyterbook-navigation`
 To install the extension, execute:
 
 ```bash
-pip install jupyterlab_jupyterbook_navigation
+python -m pip install jupyterlab_jupyterbook_navigation
 ```
 
 ## Uninstall
@@ -26,7 +26,7 @@ pip install jupyterlab_jupyterbook_navigation
 To remove the extension, execute:
 
 ```bash
-pip uninstall jupyterlab_jupyterbook_navigation
+python -m pip uninstall jupyterlab_jupyterbook_navigation
 ```
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jupyterlab-jupyterbook-navigation",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "A JupyterLab extension that mimics jupyter-book chapter navigation on an un-built, cloned jupyter book in JupyterLab.",
     "keywords": [
         "jupyter",


### PR DESCRIPTION
Update prep-release and publish-release workflows:
- release to PyPi via OIDC
- release to NPM with an access token
- Update pip installation instructions in README
- hatch v1.0.3