### PR TITLE
Name change and add Jupyter Book 2 support

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -8,12 +8,12 @@ file_extension: ''
 has_binder: true
 has_settings: false
 kind: frontend
-labextension_name: jupyterlab-jupyterbook-navigation
+labextension_name: jb-toc
 mimetype: ''
 mimetype_name: ''
 project_short_description: "A JupyterLab extension that mimics jupyter-book chapter navigation on an un-built, cloned jupyter book in JupyterLab."
-python_name: jupyterlab_jupyterbook_navigation
-repository: https://github.com/ASFOpenSARlab/jupyterlab-jupyterbook-navigation
+python_name: jb_toc
+repository: https://github.com/ASFOpenSARlab/jb-toc
 test: true
 viewer_name: ''
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
         python -m pip install .[test]
 
         jupyter labextension list
-        jupyter labextension list 2>&1 | grep -ie "jupyterlab-jupyterbook-navigation.*OK"
+        jupyter labextension list 2>&1 | grep -ie "jb-toc.*OK"
         python -m jupyterlab.browser_check
 
     - name: Package the extension
@@ -46,13 +46,13 @@ jobs:
 
         pip install build
         python -m build
-        pip uninstall -y "jupyterlab_jupyterbook_navigation" jupyterlab
+        pip uninstall -y "jb_toc" jupyterlab
 
     - name: Upload extension packages
       uses: actions/upload-artifact@v4
       with:
         name: extension-artifacts
-        path: dist/jupyterlab_jupyterbook_navigation*
+        path: dist/jb_toc*
         if-no-files-found: error
 
   test_isolated:
@@ -75,10 +75,10 @@ jobs:
         sudo rm -rf $(which node)
         sudo rm -rf $(which node)
 
-        pip install "jupyterlab>=4.0.0,<5" jupyterlab_jupyterbook_navigation*.whl
+        pip install "jupyterlab>=4.0.0,<5" jb_toc*.whl
 
         jupyter labextension list
-        jupyter labextension list 2>&1 | grep -ie "jupyterlab-jupyterbook-navigation.*OK"
+        jupyter labextension list 2>&1 | grep -ie "jb-toc.*OK"
         python -m jupyterlab.browser_check --no-browser-test
 
   integration-tests:
@@ -104,7 +104,7 @@ jobs:
     - name: Install the extension
       run: |
         set -eux
-        python -m pip install "jupyterlab>=4.0.0,<5" jupyterlab_jupyterbook_navigation*.whl
+        python -m pip install "jupyterlab>=4.0.0,<5" jb_toc*.whl
 
     - name: Install dependencies
       working-directory: ui-tests
@@ -133,7 +133,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: jupyterlab_jupyterbook_navigation-playwright-tests
+        name: jb_toc-playwright-tests
         path: |
           ui-tests/test-results
           ui-tests/playwright-report

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -26,5 +26,5 @@ jobs:
       - name: Upload Distributions
         uses: actions/upload-artifact@v4
         with:
-          name: jupyterlab_jupyterbook_navigation-releaser-dist-${{ github.run_number }}
+          name: jb_toc-releaser-dist-${{ github.run_number }}
           path: .jupyter_releaser_checkout/dist

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -35,23 +35,6 @@ jobs:
           release_url: ${{ github.event.inputs.release_url }}
           steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
 
-      # - name: Get Release Version
-      #   id: get-version
-      #   run: |
-      #     VERSION=$(gh release view "${{ steps.populate-release.outputs.release_url }}" --json name -q ".name")
-      #     echo "VERSION=$VERSION" >> $GITHUB_ENV
-
-      # - name: Tag Release
-      #   id: tag-release
-      #   env:
-      #     GH_TOKEN: ${{ secrets.PUBLISH_GITHUB_PAT }}
-      #   run: |
-      #     git config user.email "${{ github.actor }}@users.noreply.github.com"
-      #     git config user.name "${{ github.actor }}"
-      #     git remote set-url origin https://x-access-token:${{ secrets.PUBLISH_GITHUB_PAT }}@github.com/${{ github.repository }}
-      #     git commit --allow-empty -am "Publish ${VERSION}"
-      #     jupyter-releaser tag-release
-
       - name: Finalize Release
         id: finalize-release
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,9 @@ node_modules/
 *.egg-info/
 .ipynb_checkpoints
 *.tsbuildinfo
-jupyterlab_jupyterbook_navigation/labextension
+jb_toc/labextension
 # Version file is handled by hatchling
-jupyterlab_jupyterbook_navigation/_version.py
+jb_toc/_version.py
 
 # Integration tests
 ui-tests/test-results/

--- a/.prettierignore
+++ b/.prettierignore
@@ -3,4 +3,4 @@ node_modules
 **/lib
 **/package.json
 !/package.json
-jupyterlab_jupyterbook_navigation
+jb_toc

--- a/README.md
+++ b/README.md
@@ -1,24 +1,24 @@
 # jupyterlab_jupyterbook_navigation
 
-[![Github Actions Status](https://github.com/ASFOpenSARlab/jupyterlab-jupyterbook-navigation/workflows/Build/badge.svg)](https://github.com/Alex-Lewandowski/jupyterlab-jbook-chapter-navigation/actions/workflows/build.yml)[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ASFOpenSARlab/jupyterlab-jupyterbook-navigation/main?urlpath=lab)
+[![Github Actions Status](https://github.com/ASFOpenSARlab/jb-toc/workflows/Build/badge.svg)](https://github.com/ASFOpenSARlab/jb-toc/actions/workflows/build.yml)[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/ASFOpenSARlab/jb-toc/main?urlpath=lab)
 [![lite-badge](https://jupyterlite.rtfd.io/en/latest/_static/badge.svg)](https://alex-lewandowski.github.io/JupyterLite-demo/lab/index.html)
 
 A JupyterLab server extension that provides Jupyter-Book navigation in a sidepanel widget with a Jupyter-Book table of contents.
 
-https://github.com/ASFOpenSARlab/jupyterlab-jupyterbook-navigation/assets/37909088/3aa48f43-dfeb-466d-8f33-afc10f333f50
+https://github.com/ASFOpenSARlab/jb-toc/assets/37909088/3aa48f43-dfeb-466d-8f33-afc10f333f50
 
-NPM frontend extension: `jupyterlab-jupyterbook-navigation`
+NPM frontend extension: `jb-toc`
 
 ## Requirements
 
-- JupyterLab >= 4.0.0
+- JupyterLab >= 4.0.0 < 5
 
 ## Install
 
 To install the extension, execute:
 
 ```bash
-python -m pip install jupyterlab_jupyterbook_navigation
+python -m pip install jb_toc
 ```
 
 ## Uninstall
@@ -26,7 +26,7 @@ python -m pip install jupyterlab_jupyterbook_navigation
 To remove the extension, execute:
 
 ```bash
-python -m pip uninstall jupyterlab_jupyterbook_navigation
+python -m pip uninstall jb_toc
 ```
 
 ## Contributing
@@ -41,7 +41,7 @@ The `jlpm` command is JupyterLab's pinned version of
 
 ```bash
 # Clone the repo to your local environment
-# Change directory to the jupyterlab_jupyterbook_navigation directory
+# Change directory to the jb_toc directory
 # Install package in development mode
 pip install -e "."
 # Link your development version of the extension with JupyterLab
@@ -70,12 +70,12 @@ jupyter lab build --minimize=False
 ### Development uninstall
 
 ```bash
-pip uninstall jupyterlab_jupyterbook_navigation
+pip uninstall jb_toc
 ```
 
 In development mode, you will also need to remove the symlink created by `jupyter labextension develop`
 command. To find its location, you can run `jupyter labextension list` to figure out where the `labextensions`
-folder is located. Then you can remove the symlink named `jupyterlab-jupyterbook-navigation` within that folder.
+folder is located. Then you can remove the symlink named `jb-toc` within that folder.
 
 ### Testing the extension
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-# Making a new release of jupyterlab_jupyterbook_navigation
+# Making a new release of jb_toc
 
 The extension can be published to `PyPI` and `npm` manually or using the [Jupyter Releaser](https://github.com/jupyter-server/jupyter_releaser).
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,17 +1,17 @@
-# a mybinder.org-ready environment for demoing jupyterlab_jupyterbook_navigation
+# a mybinder.org-ready environment for demoing jb_toc
 # this environment may also be used locally on Linux/MacOS/Windows, e.g.
 #
 #   conda env update --file binder/environment.yml
-#   conda activate jupyterlab-jupyterbook-navigation-demo
+#   conda activate jb-toc-demo
 #
-name: jupyterlab-jupyterbook-navigation-demo
+name: jb-toc-demo
 
 channels:
   - conda-forge
 
 dependencies:
   # runtime dependencies
-  - python >=3.10,<3.11.0a0
+  - python >=3.10,<3.13
   - jupyterlab >=4.0.0,<5
   # labextension build dependencies
   - nodejs >=18,<19

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-""" perform a development install of jupyterlab_jupyterbook_navigation
+""" perform a development install of jb_toc
 
     On Binder, this will run _after_ the environment has been fully created from
     the environment.yml in this directory.
@@ -43,5 +43,5 @@ _("jupyter", "server", "extension", "list")
 _("jupyter", "labextension", "list")
 
 
-print("JupyterLab with jupyterlab_jupyterbook_navigation is ready to run with:\n")
+print("JupyterLab with jb_toc is ready to run with:\n")
 print("\tjupyter lab\n")

--- a/install.json
+++ b/install.json
@@ -1,5 +1,5 @@
 {
   "packageManager": "python",
-  "packageName": "jupyterlab_jupyterbook_navigation",
-  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package jupyterlab_jupyterbook_navigation"
+  "packageName": "jb_toc",
+  "uninstallInstructions": "Use your Python package manager (pip, conda, etc.) to uninstall the package jb_toc"
 }

--- a/jb_toc/__init__.py
+++ b/jb_toc/__init__.py
@@ -5,12 +5,12 @@ except ImportError:
     # in editable mode with pip. It is highly recommended to install
     # the package from a stable release or in editable mode: https://pip.pypa.io/en/stable/topics/local-project-installs/#editable-installs
     import warnings
-    warnings.warn("Importing 'jupyterlab_jupyterbook_navigation' outside a proper installation.")
+    warnings.warn("Importing 'jb_toc' outside a proper installation.")
     __version__ = "dev"
 
 
 def _jupyter_labextension_paths():
     return [{
         "src": "labextension",
-        "dest": "jupyterlab-jupyterbook-navigation"
+        "dest": "jb-toc"
     }]

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "jupyterlab-jupyterbook-navigation",
+    "name": "jb-toc",
     "version": "1.0.4",
     "description": "A JupyterLab extension that mimics jupyter-book chapter navigation on an un-built, cloned jupyter book in JupyterLab.",
     "keywords": [
@@ -7,9 +7,9 @@
         "jupyterlab",
         "jupyterlab-extension"
     ],
-    "homepage": "https://github.com/ASFOpenSARlab/jupyterlab-jupyterbook-navigation",
+    "homepage": "https://github.com/ASFOpenSARlab/jb-toc",
     "bugs": {
-        "url": "https://github.com/ASFOpenSARlab/jupyterlab-jupyterbook-navigation/issues"
+        "url": "https://github.com/ASFOpenSARlab/jb-toc/issues"
     },
     "license": "BSD-3-Clause",
     "author": {
@@ -26,7 +26,7 @@
     "style": "style/index.css",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ASFOpenSARlab/jupyterlab-jupyterbook-navigation.git"
+        "url": "https://github.com/ASFOpenSARlab/jb-toc.git"
     },
     "scripts": {
         "build": "jlpm build:lib && jlpm build:labextension:dev",
@@ -38,7 +38,7 @@
         "clean": "jlpm clean:lib",
         "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
         "clean:lintcache": "rimraf .eslintcache .stylelintcache",
-        "clean:labextension": "rimraf jupyterlab_jupyterbook_navigation/labextension jupyterlab_jupyterbook_navigation/_version.py",
+        "clean:labextension": "rimraf jb_toc/labextension jb_toc/_version.py",
         "clean:all": "jlpm clean:lib && jlpm clean:labextension && jlpm clean:lintcache",
         "eslint": "jlpm eslint:check --fix",
         "eslint:check": "eslint . --cache --ext .ts,.tsx",
@@ -97,7 +97,7 @@
     },
     "jupyterlab": {
         "extension": true,
-        "outputDir": "jupyterlab_jupyterbook_navigation/labextension"
+        "outputDir": "jb_toc/labextension"
     },
     "eslintIgnore": [
         "node_modules",

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
                         "PascalCase"
                     ],
                     "custom": {
-                        "regex": "^I[A-Z]",
+                        "regex": "^[A-Z]",
                         "match": true
                     }
                 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling>=1.5.0", "jupyterlab>=4.0.0,<5", "hatch-nodejs-version>=0
 build-backend = "hatchling.build"
 
 [project]
-name = "jupyterlab_jupyterbook_navigation"
+name = "jb_toc"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.8"
@@ -16,11 +16,10 @@ classifiers = [
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "jupyter-server-globbing",
@@ -34,24 +33,24 @@ source = "nodejs"
 fields = ["description", "authors", "urls"]
 
 [tool.hatch.build.targets.sdist]
-artifacts = ["jupyterlab_jupyterbook_navigation/labextension"]
+artifacts = ["jb_toc/labextension"]
 exclude = [".github", "binder"]
 
 [tool.hatch.build.targets.wheel.shared-data]
-"jupyterlab_jupyterbook_navigation/labextension" = "share/jupyter/labextensions/jupyterlab-jupyterbook-navigation"
-"install.json" = "share/jupyter/labextensions/jupyterlab-jupyterbook-navigation/install.json"
+"jb_toc/labextension" = "share/jupyter/labextensions/jb-toc"
+"install.json" = "share/jupyter/labextensions/jb-toc/install.json"
 
 [tool.hatch.build.hooks.version]
-path = "jupyterlab_jupyterbook_navigation/_version.py"
+path = "jb_toc/_version.py"
 
 [tool.hatch.build.hooks.jupyter-builder]
 dependencies = ["hatch-jupyter-builder>=0.5"]
 build-function = "hatch_jupyter_builder.npm_builder"
 ensured-targets = [
-    "jupyterlab_jupyterbook_navigation/labextension/static/style.js",
-    "jupyterlab_jupyterbook_navigation/labextension/package.json",
+    "jb_toc/labextension/static/style.js",
+    "jb_toc/labextension/package.json",
 ]
-skip-if-exists = ["jupyterlab_jupyterbook_navigation/labextension/static/style.js"]
+skip-if-exists = ["jb_toc/labextension/static/style.js"]
 
 [tool.hatch.build.hooks.jupyter-builder.build-kwargs]
 build_cmd = "build:prod"
@@ -61,7 +60,7 @@ npm = ["jlpm"]
 build_cmd = "install:extension"
 npm = ["jlpm"]
 source_dir = "src"
-build_dir = "jupyterlab_jupyterbook_navigation/labextension"
+build_dir = "jb_toc/labextension"
 
 [tool.jupyter-releaser.options]
 version_cmd = "hatch version"

--- a/src/__tests__/jb_toc.spec.ts
+++ b/src/__tests__/jb_toc.spec.ts
@@ -2,7 +2,7 @@
  * Example of [Jest](https://jestjs.io/docs/getting-started) unit tests
  */
 
-describe('jupyterlab-jupyterbook-navigation', () => {
+describe('jb-toc', () => {
   it('should be tested', () => {
     expect(1 + 1).toEqual(2);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,7 @@ function toggleList(button: HTMLButtonElement): void {
   const isHidden = list.hidden;
   list.hidden = !isHidden;
 
-  button.setAttribute('aria-expanded', String(isHidden));
+  button.setAttribute('aria-expanded', String(!isHidden));
   button.innerHTML = isHidden
     ? '<i class="fa fa-chevron-up toc-chevron"></i>'
     : '<i class="fa fa-chevron-down toc-chevron"></i>';

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,7 +25,7 @@ export function getJupyterAppInstance(app?: JupyterFrontEnd): JupyterFrontEnd {
 }
 
 const plugin: JupyterFrontEndPlugin<void> = {
-  id: 'jupyterlab-jupyterbook-navigation:plugin',
+  id: 'jb-toc:plugin',
   description:
     'A JupyterLab extension that mimics jupyter-book chapter navigation on an un-built, cloned jupyter book in JupyterLab.',
   autoStart: true,
@@ -38,11 +38,11 @@ const plugin: JupyterFrontEndPlugin<void> = {
   ) => {
     getJupyterAppInstance(app);
     console.log(
-      'JupyterLab extension jupyterlab-jupyterbook-navigation is activated!'
+      'JupyterLab extension jb-toc is activated!'
     );
 
     const widget = new Widget();
-    widget.id = '@jupyterlab-sidepanel/jupyterbook-toc';
+    widget.id = '@jupyterlab-sidepanel/jb-toc';
     widget.title.iconClass = 'jbook-icon jp-SideBar-tabIcon';
     widget.title.className = 'jbook-tab';
     widget.title.caption = 'Jupyter-Book Table of Contents';
@@ -66,7 +66,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
         addClickListenerToButtons(fileBrowser, docManager);
         addClickListenerToChevron();
       } catch (reason) {
-        console.error(`The jupyterlab_jupyterbook_navigation error: ${reason}`);
+        console.error(`jb_toc error: ${reason}`);
       }
     };
     shell.add(widget, 'left', { rank: 400 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,6 @@ function addClickListenerToChevron() {
   buttons.forEach(buttonElement => {
     const button = buttonElement as HTMLButtonElement;
     button.addEventListener('click', (event: Event) => {
-      console.log('Button clicked');
       toggleList(button);
     });
   });
@@ -104,8 +103,6 @@ function addClickListenerToButtons(
   const buttons = document.querySelectorAll('.toc-button');
   buttons.forEach(button => {
     button.addEventListener('click', (event: Event) => {
-      console.log('Button clicked');
-
       if (!fileBrowser) {
         console.error('File browser not found');
         return;
@@ -129,7 +126,7 @@ function addClickListenerToButtons(
         );
         return;
       }
-      console.log(`Current directory: ${fileBrowser.model.path}`);
+      console.debug(`Current directory: ${fileBrowser.model.path}`);
 
       const filePath = button.getAttribute('data-file-path');
       if (typeof filePath === 'string') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -85,15 +85,16 @@ function addClickListenerToChevron() {
 }
 
 function toggleList(button: HTMLButtonElement): void {
-  const list = button.parentElement?.nextElementSibling as HTMLElement;
+  const list = button.parentElement?.nextElementSibling as HTMLElement | null;
+  if (!list) return;
 
-  if (list.style.display === 'none') {
-    list.style.display = 'block';
-    button.innerHTML = '<i class="fa fa-chevron-up toc-chevron"></i>';
-  } else {
-    list.style.display = 'none';
-    button.innerHTML = '<i class="fa fa-chevron-down toc-chevron"></i>';
-  }
+  const isHidden = list.hidden;
+  list.hidden = !isHidden;
+
+  button.setAttribute('aria-expanded', String(isHidden));
+  button.innerHTML = isHidden
+    ? '<i class="fa fa-chevron-up toc-chevron"></i>'
+    : '<i class="fa fa-chevron-down toc-chevron"></i>';
 }
 
 function addClickListenerToButtons(

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,9 +37,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     docManager: IDocumentManager
   ) => {
     getJupyterAppInstance(app);
-    console.log(
-      'JupyterLab extension jb-toc is activated!'
-    );
+    console.log('JupyterLab extension jb-toc is activated!');
 
     const widget = new Widget();
     widget.id = '@jupyterlab-sidepanel/jb-toc';

--- a/src/index.ts
+++ b/src/index.ts
@@ -86,7 +86,9 @@ function addClickListenerToChevron() {
 
 function toggleList(button: HTMLButtonElement): void {
   const list = button.parentElement?.nextElementSibling as HTMLElement | null;
-  if (!list) return;
+  if (!list) {
+    return;
+  }
 
   const isHidden = list.hidden;
   list.hidden = !isHidden;

--- a/src/jb1.ts
+++ b/src/jb1.ts
@@ -71,7 +71,7 @@ async function getSubSection(
     if (!title) {
       title = file;
     }
-    html += `<button class="jp-Button toc-button tb-level${level}" style="display: block;" data-file-path="${jbtoc.escapeHtml(String(pth))}">${jbtoc.escapeHtml(String(title))}</button>`;
+    html += `<button class="jp-Button toc-button tb-level${level}" style="display: block;" data-file-path="${jbtoc.escAttr(encodeURI(String(pth)))}">${jbtoc.escHtml(String(title))}</button>`;
   }
   for (const k of parts) {
     if (k.sections && k.file) {
@@ -83,10 +83,10 @@ async function getSubSection(
       if (!title) {
         title = k.file;
       }
-      title = jbtoc.escapeHtml(String(title));
+      title = jbtoc.escHtml(String(title));
       html += `
         <div>
-            <button class="jp-Button toc-button tb-level${level}"style="display: inline-block;" data-file-path="${jbtoc.escapeHtml(String(pth))}">${jbtoc.escapeHtml(String(title))}</button>
+            <button class="jp-Button toc-button tb-level${level}"style="display: inline-block;" data-file-path="${jbtoc.escAttr(encodeURI(String(pth)))}">${jbtoc.escHtml(String(title))}</button>
             <button class="jp-Button toc-chevron" style="display: inline-block;"><i class="fa fa-chevron-down "></i></button>
         </div>
         <div style="display: none;">
@@ -103,8 +103,8 @@ async function getSubSection(
     } else if (k.file) {
       await insertFile(k.file);
     } else if (k.url) {
-      const url = String(jbtoc.escapeHtml(k.url));
-      html += `<button class="jp-Button toc-button tb-level${level}" style="display:block;"><a class="toc-link tb-level${level}" href="${jbtoc.escapeHtml(String(url))}" target="_blank" rel="noopener noreferrer" style="display: block;">${jbtoc.escapeHtml(String(k.title))}</a></button>`;
+      const url = String(jbtoc.escAttr(encodeURI(k.url)));
+      html += `<button class="jp-Button toc-button tb-level${level}" style="display:block;"><a class="toc-link tb-level${level}" href="${jbtoc.escAttr(encodeURI(String(url)))}" target="_blank" rel="noopener noreferrer" style="display: block;">${jbtoc.escHtml(String(k.title))}</a></button>`;
     } else if (k.glob) {
       const files = await jbtoc.globFiles(`${cwd}${k.glob}`);
       for (const file of files) {
@@ -123,7 +123,7 @@ export async function jBook1TOCToHtml(
   let html = '\n<ul>';
   if (toc.parts) {
     for (const chapter of toc.parts) {
-      html += `\n<p class="caption" role="heading"><span class="caption-text"><b>\n${jbtoc.escapeHtml(String(chapter.caption))}\n</b></span>\n</p>`;
+      html += `\n<p class="caption" role="heading"><span class="caption-text"><b>\n${jbtoc.escHtml(String(chapter.caption))}\n</b></span>\n</p>`;
       const subSectionHtml = await getSubSection(chapter.chapters, cwd);
       html += `\n${subSectionHtml}`;
     }

--- a/src/jb1.ts
+++ b/src/jb1.ts
@@ -1,0 +1,234 @@
+import * as path from 'path';
+import * as yaml from 'js-yaml';
+import { getJupyterAppInstance } from './index';
+
+import * as jbtoc from './jbtoc';
+
+interface IFileMetadata {
+  path: string;
+}
+
+interface IJbookConfig {
+  title: string;
+  author: string;
+  logo: string;
+}
+
+export interface IToc {
+  parts?: IPart[];
+  chapters?: ISection[];
+  caption?: string;
+}
+
+interface ISection {
+  sections?: ISection[];
+  file?: string;
+  url?: string;
+  title?: string;
+  glob?: string;
+}
+
+interface IPart {
+  caption: string;
+  chapters: ISection[];
+}
+
+interface INotebook {
+  cells: ICell[];
+}
+
+interface ICell {
+  cell_type: 'markdown';
+  metadata: { object: any };
+  source: string;
+}
+
+function isNotebook(obj: any): obj is INotebook {
+  return obj && typeof obj === 'object' && Array.isArray(obj.cells);
+}
+
+async function getTitle(filePath: string): Promise<string | null> {
+  const suffix = path.extname(filePath);
+  if (suffix === '.ipynb') {
+    try {
+      const jsonData: INotebook | string = await jbtoc.getFileContents(filePath);
+      if (isNotebook(jsonData)) {
+        const headerCells = jsonData.cells.filter(cell => {
+          if (cell.cell_type === 'markdown') {
+            const source = Array.isArray(cell.source)
+              ? cell.source.join('')
+              : cell.source;
+            return source.split('\n').some(line => line.startsWith('# '));
+          }
+          return false;
+        });
+
+        const firstHeaderCell = headerCells.length > 0 ? headerCells[0] : null;
+        if (firstHeaderCell) {
+          if (firstHeaderCell.source.split('\n')[0].slice(0, 2) === '# ') {
+            const title: string = firstHeaderCell.source
+              .split('\n')[0]
+              .slice(2);
+            return title;
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Error reading or parsing notebook:', error);
+    }
+  } else if (suffix === '.md') {
+    try {
+      const md: INotebook | string = await jbtoc.getFileContents(filePath);
+      if (!isNotebook(md)) {
+        const lines: string[] = md.split('\n');
+        for (const line of lines) {
+          if (line.slice(0, 2) === '# ') {
+            return line.slice(2);
+          }
+        }
+      }
+    } catch (error) {
+      console.error('Error reading or parsing Markdown:', error);
+    }
+  }
+  return null;
+}
+
+function isIJbookConfig(obj: any): obj is IJbookConfig {
+  return obj && typeof obj === 'object' && obj.title && obj.author;
+}
+
+export async function getBookConfig(
+  configPath: string
+): Promise<{ title: string | null; author: string | null }> {
+  try {
+    const yamlStr = await jbtoc.getFileContents(configPath);
+    if (typeof yamlStr === 'string') {
+      const config: unknown = yaml.load(yamlStr);
+      if (isIJbookConfig(config)) {
+        const title = config.title || 'Untitled Jupyter Book';
+        const author = config.author || 'Anonymous';
+        return { title, author };
+      } else {
+        console.error('Error: Misconfigured Jupyter Book config.');
+      }
+    }
+  } catch (error) {
+    console.error('Error reading or parsing config:', error);
+  }
+  return { title: null, author: null };
+}
+
+
+async function globFiles(pattern: string): Promise<string[]> {
+  const baseDir = '';
+  const result: string[] = [];
+
+  try {
+    const app = getJupyterAppInstance();
+    const data = await app.serviceManager.contents.get(baseDir, {
+      content: true
+    });
+    const regex = new RegExp(pattern);
+    for (const item of data.content) {
+      if (item.type === 'file' && regex.test(item.path)) {
+        result.push(item.path);
+      }
+    }
+  } catch (error) {
+    console.error(`Error globbing pattern ${pattern}`, error);
+  }
+
+  return result;
+}
+
+async function getFullPath(file_pattern: string, dir_pth: string) {
+  const files = await jbtoc.ls(dir_pth);
+  for (const value of Object.values(files.content)) {
+    const file = value as IFileMetadata;
+    if (file.path.includes(file_pattern)) {
+      return file.path;
+    }
+  }
+  return `Unable to locate ${file_pattern} in ${dir_pth}`;
+}
+
+async function getSubSection(
+  parts: ISection[],
+  cwd: string,
+  level: number = 1,
+  html: string = ''
+): Promise<string> {
+  if (cwd && cwd.slice(-1) !== '/') {
+    cwd = cwd + '/';
+  }
+
+  async function insert_one_file(file: string) {
+    const parts = file.split('/');
+    parts.pop();
+    const k_dir = parts.join('/');
+    const pth = await getFullPath(file, `${cwd}${k_dir}`);
+    let title = await getTitle(pth);
+    if (!title) {
+      title = file;
+    }
+    html += `<button class="jp-Button toc-button tb-level${level}" style="display: block;" data-file-path="${pth}">${title}</button>`;
+  }
+  for (const k of parts) {
+    if (k.sections && k.file) {
+      const parts = k.file.split('/');
+      parts.pop();
+      const k_dir = parts.join('/');
+      const pth = await getFullPath(k.file, `${cwd}${k_dir}`);
+      let title = await getTitle(pth);
+      if (!title) {
+        title = k.file;
+      }
+      html += `
+        <div>
+            <button class="jp-Button toc-button tb-level${level}"style="display: inline-block;" data-file-path="${pth}">${title}</button>
+            <button class="jp-Button toc-chevron" style="display: inline-block;"><i class="fa fa-chevron-down "></i></button>
+        </div>
+        <div style="display: none;">
+        `;
+      const html_cur = html;
+      html = await getSubSection(
+        k.sections,
+        cwd,
+        (level = level + 1),
+        (html = html_cur)
+      );
+      level = level - 1;
+      html += '</div>';
+    } else if (k.file) {
+      await insert_one_file(k.file);
+    } else if (k.url) {
+      html += `<button class="jp-Button toc-button tb-level${level}" style="display:block;"><a class="toc-link tb-level${level}" href="${k.url}" target="_blank" rel="noopener noreferrer" style="display: block;">${k.title}</a></button>`;
+    } else if (k.glob) {
+      const files = await globFiles(`${cwd}${k.glob}`);
+      for (const file of files) {
+        const relative = file.replace(`${cwd}`, '');
+        await insert_one_file(relative);
+      }
+    }
+  }
+  return html;
+}
+
+export async function tocToHtml(toc: IToc, cwd: string): Promise<string> {
+  let html = '\n<ul>';
+  if (toc.parts) {
+    for (const chapter of toc.parts) {
+      html += `\n<p class="caption" role="heading"><span class="caption-text"><b>\n${chapter.caption}\n</b></span>\n</p>`;
+      const subISectionHtml = await getSubSection(chapter.chapters, cwd);
+      html += `\n${subISectionHtml}`;
+    }
+  } else {
+    if (toc.chapters) {
+      const subISectionHtml = await getSubSection(toc.chapters, cwd);
+      html += `\n${subISectionHtml}`;
+    }
+  }
+  html += '\n</ul>';
+  return html;
+}

--- a/src/jb1.ts
+++ b/src/jb1.ts
@@ -71,7 +71,7 @@ async function getSubSection(
     if (!title) {
       title = file;
     }
-    html += `<button class="jp-Button toc-button tb-level${level}" style="display: block;" data-file-path="${pth}">${title}</button>`;
+    html += `<button class="jp-Button toc-button tb-level${level}" style="display: block;" data-file-path="${jbtoc.escapeHtml(String(pth))}">${jbtoc.escapeHtml(String(title))}</button>`;
   }
   for (const k of parts) {
     if (k.sections && k.file) {
@@ -83,9 +83,10 @@ async function getSubSection(
       if (!title) {
         title = k.file;
       }
+      title = jbtoc.escapeHtml(String(title));
       html += `
         <div>
-            <button class="jp-Button toc-button tb-level${level}"style="display: inline-block;" data-file-path="${pth}">${title}</button>
+            <button class="jp-Button toc-button tb-level${level}"style="display: inline-block;" data-file-path="${jbtoc.escapeHtml(String(pth))}">${jbtoc.escapeHtml(String(title))}</button>
             <button class="jp-Button toc-chevron" style="display: inline-block;"><i class="fa fa-chevron-down "></i></button>
         </div>
         <div style="display: none;">
@@ -102,7 +103,8 @@ async function getSubSection(
     } else if (k.file) {
       await insertFile(k.file);
     } else if (k.url) {
-      html += `<button class="jp-Button toc-button tb-level${level}" style="display:block;"><a class="toc-link tb-level${level}" href="${k.url}" target="_blank" rel="noopener noreferrer" style="display: block;">${k.title}</a></button>`;
+      const url = String(jbtoc.escapeHtml(k.url));
+      html += `<button class="jp-Button toc-button tb-level${level}" style="display:block;"><a class="toc-link tb-level${level}" href="${jbtoc.escapeHtml(String(url))}" target="_blank" rel="noopener noreferrer" style="display: block;">${jbtoc.escapeHtml(String(k.title))}</a></button>`;
     } else if (k.glob) {
       const files = await jbtoc.globFiles(`${cwd}${k.glob}`);
       for (const file of files) {
@@ -121,7 +123,7 @@ export async function jBook1TOCToHtml(
   let html = '\n<ul>';
   if (toc.parts) {
     for (const chapter of toc.parts) {
-      html += `\n<p class="caption" role="heading"><span class="caption-text"><b>\n${chapter.caption}\n</b></span>\n</p>`;
+      html += `\n<p class="caption" role="heading"><span class="caption-text"><b>\n${jbtoc.escapeHtml(String(chapter.caption))}\n</b></span>\n</p>`;
       const subSectionHtml = await getSubSection(chapter.chapters, cwd);
       html += `\n${subSectionHtml}`;
     }

--- a/src/jb1.ts
+++ b/src/jb1.ts
@@ -28,7 +28,12 @@ interface Part {
 }
 
 function isJBook1Config(obj: any): obj is JBook1Config {
-  return obj && typeof obj === 'object' && obj.title && obj.author;
+  return (
+    obj &&
+    typeof obj === 'object' &&
+    typeof obj.title === 'string' &&
+    typeof obj.author === 'string'
+  );
 }
 
 export async function getJBook1Config(

--- a/src/jb1.ts
+++ b/src/jb1.ts
@@ -86,7 +86,10 @@ async function getSubSection(
       title = jbtoc.escHtml(String(title));
       html += `
         <div>
-            <button class="jp-Button toc-button tb-level${level}"style="display: inline-block;" data-file-path="${jbtoc.escAttr(encodeURI(String(pth)))}">${jbtoc.escHtml(String(title))}</button>
+            <button class="jp-Button toc-button 
+              tb-level${level}"style="display: inline-block;" 
+              data-file-path="${jbtoc.escAttr(encodeURI(String(pth)))}"
+              >${jbtoc.escHtml(String(title))}</button>
             <button class="jp-Button toc-chevron" style="display: inline-block;"><i class="fa fa-chevron-down "></i></button>
         </div>
         <div style="display: none;">
@@ -104,7 +107,13 @@ async function getSubSection(
       await insertFile(k.file);
     } else if (k.url) {
       const url = String(jbtoc.escAttr(encodeURI(k.url)));
-      html += `<button class="jp-Button toc-button tb-level${level}" style="display:block;"><a class="toc-link tb-level${level}" href="${jbtoc.escAttr(encodeURI(String(url)))}" target="_blank" rel="noopener noreferrer" style="display: block;">${jbtoc.escHtml(String(k.title))}</a></button>`;
+      html += `<button class="jp-Button toc-button tb-level${level}" style="display:block;">
+        <a class="toc-link tb-level${level}" 
+        href="${jbtoc.escAttr(encodeURI(String(url)))}" 
+        target="_blank" 
+        rel="noopener noreferrer" 
+        style="display: block;"
+        >${jbtoc.escHtml(String(k.title))}</a></button>`;
     } else if (k.glob) {
       const files = await jbtoc.globFiles(`${cwd}${k.glob}`);
       for (const file of files) {

--- a/src/jb1.ts
+++ b/src/jb1.ts
@@ -67,7 +67,10 @@ async function getSubSection(
     parts.pop();
     const k_dir = parts.join('/');
     const pth = await jbtoc.getFullPath(file, `${cwd}${k_dir}`);
-    let title = await jbtoc.getFileTitleFromHeader(pth);
+    let title;
+    if (typeof(pth) === 'string') {
+      title = await jbtoc.getFileTitleFromHeader(pth);
+    }
     if (!title) {
       title = file;
     }
@@ -79,7 +82,10 @@ async function getSubSection(
       parts.pop();
       const k_dir = parts.join('/');
       const pth = await jbtoc.getFullPath(k.file, `${cwd}${k_dir}`);
-      let title = await jbtoc.getFileTitleFromHeader(pth);
+      let title;
+      if (typeof(pth) === 'string') {
+        title = await jbtoc.getFileTitleFromHeader(pth);
+      }
       if (!title) {
         title = k.file;
       }

--- a/src/jb1.ts
+++ b/src/jb1.ts
@@ -68,7 +68,7 @@ async function getSubSection(
     const k_dir = parts.join('/');
     const pth = await jbtoc.getFullPath(file, `${cwd}${k_dir}`);
     let title;
-    if (typeof(pth) === 'string') {
+    if (typeof pth === 'string') {
       title = await jbtoc.getFileTitleFromHeader(pth);
     }
     if (!title) {
@@ -83,7 +83,7 @@ async function getSubSection(
       const k_dir = parts.join('/');
       const pth = await jbtoc.getFullPath(k.file, `${cwd}${k_dir}`);
       let title;
-      if (typeof(pth) === 'string') {
+      if (typeof pth === 'string') {
         title = await jbtoc.getFileTitleFromHeader(pth);
       }
       if (!title) {

--- a/src/jb1.ts
+++ b/src/jb1.ts
@@ -79,7 +79,7 @@ async function getSubSection(
     if (!title) {
       title = file;
     }
-    html += `<button class="jp-Button toc-button tb-level${level}" style="display: block;" data-file-path="${jbtoc.escAttr(encodeURI(String(pth)))}">${jbtoc.escHtml(String(title))}</button>`;
+    html += `<button class="jp-Button toc-button tb-level${level}" data-file-path="${jbtoc.escAttr(encodeURI(String(pth)))}">${jbtoc.escHtml(String(title))}</button>`;
   }
   for (const k of parts) {
     if (k.sections && k.file) {
@@ -96,14 +96,14 @@ async function getSubSection(
       }
       title = jbtoc.escHtml(String(title));
       html += `
-        <div>
-            <button class="jp-Button toc-button 
-              tb-level${level}"style="display: inline-block;" 
+        <div class="toc-row">
+            <button type="button" class="jp-Button toc-button 
+              tb-level${level}" 
               data-file-path="${jbtoc.escAttr(encodeURI(String(pth)))}"
               >${jbtoc.escHtml(String(title))}</button>
-            <button class="jp-Button toc-chevron" style="display: inline-block;"><i class="fa fa-chevron-down "></i></button>
+            <button type="button" class="jp-Button toc-chevron"><i class="fa fa-chevron-down "></i></button>
         </div>
-        <div style="display: none;">
+        <div class="toc-children" hidden>
         `;
       const html_cur = html;
       html = await getSubSection(
@@ -118,12 +118,11 @@ async function getSubSection(
       await insertFile(k.file);
     } else if (k.url) {
       const url = String(jbtoc.escAttr(encodeURI(k.url)));
-      html += `<button class="jp-Button toc-button tb-level${level}" style="display:block;">
+      html += `<button class="jp-Button toc-button toc-link tb-level${level}">
         <a class="toc-link tb-level${level}" 
         href="${jbtoc.escAttr(encodeURI(String(url)))}" 
         target="_blank" 
         rel="noopener noreferrer" 
-        style="display: block;"
         >${jbtoc.escHtml(String(k.title))}</a></button>`;
     } else if (k.glob) {
       const files = await jbtoc.globFiles(`${cwd}${k.glob}`);

--- a/src/jb2.ts
+++ b/src/jb2.ts
@@ -87,7 +87,6 @@ export async function mystTOCToHtml(
       url = jbtoc.escapeHtml(String(item.url));
     }
 
-    console.log(item);
     if ((item.title || item.file) && item.children) {
       // If there are a title, children, and a file, use the file path as the title
       if (item.file) {
@@ -132,10 +131,7 @@ export async function getHtmlTop(
   if (project.subtitle) {
     html_top += `<p id="toc-subtitle">${jbtoc.escapeHtml(String(project.subtitle))}</p>`;
   }
-  html_top += '<br><hr class="toc-hr">';
-  
-  console.log(html_top);
-  
+  html_top += '<br><hr class="toc-hr">';  
   return html_top;
 }
 
@@ -203,8 +199,5 @@ export async function getHtmlBottom(project: MystProject): Promise<string> {
       <p style="padding-left: 15px">Copyright © ${jbtoc.escapeHtml(String(project.copyright))}</p>
     `;
   }
-
-  console.log(html_bottom);
-
   return html_bottom;
 }

--- a/src/jb2.ts
+++ b/src/jb2.ts
@@ -1,3 +1,8 @@
+// import * as path from 'path';
+// import * as yaml from 'js-yaml';
+// import { getJupyterAppInstance } from './index';
+
+import * as jbtoc from './jbtoc';
 export interface IMyst {
   project?: IMystProject;
 }
@@ -14,9 +19,6 @@ export interface IMystProject {
   affliliations?: string[];
   doi?: string;
   github?: string;
-  arxiv?: string;
-  pmid?: string;
-  open_access?: string;
   license?: string;
   copyright?: string;
   social?: string
@@ -36,17 +38,105 @@ export interface IMystTOC {
   file?: string;
   title?: string;
   children?: IMystTOC[];
+  url?: string;
+  glob?: string;
+}
+
+async function getSubSection(
+  toc: IMystTOC[],
+  cwd: string,
+  level: number = 1,
+  html: string = ''
+): Promise<string> {
+  if (cwd && cwd.slice(-1) !== '/') {
+    cwd = cwd + '/';
+  }
+
+  async function insert_one_file(file: string, chevron: boolean=false) {
+    const parts = file.split('/');
+    parts.pop();
+    const k_dir = parts.join('/');
+    const pth = await jbtoc.getFullPath(file, `${cwd}${k_dir}`);
+    let title = await jbtoc.getTitle(pth);
+    if (!title) {
+      title = file;
+    }
+    if (chevron) {
+      html += `
+        <div>
+            <button class="jp-Button toc-button tb-level${level}"style="display: inline-block;" data-file-path="${pth}">${title}</button>
+            <button class="jp-Button toc-chevron" style="display: inline-block;"><i class="fa fa-chevron-down "></i></button>
+        </div>
+        <div style="display: none;">
+        `;
+    }
+    else {
+      html += `<button class="jp-Button toc-button tb-level${level}" style="display: block;" data-file-path="${pth}">${title}</button>`;
+    }
+  }
+
+  async function insert_title(title: string) {
+
+    html += `
+    <div style="display: flex; align-items: center; justify-content: space-between;">
+        <p class="caption tb-level${level}" role="heading" style="margin: 0;">
+        <span class="caption-text"><b>${title}</b></span></p>
+        <button class="jp-Button toc-chevron" style="display: inline-block;"><i class="fa fa-chevron-down "></i></button>
+    </div>
+    <div style="display: none;">
+    `;
+  }
+
+  for (const item of toc) {
+    console.log(item);
+    if (item.title && item.children) {
+      // If there are a title, children, and a file, use the file as the title   
+      if (item.file) {
+        await insert_one_file(item.file, true);
+      }
+      else {
+        insert_title(item.title);
+      }
+      const html_cur = html;
+      html = await getSubSection(
+        item.children,
+        cwd,
+        (level = level + 1),
+        (html = html_cur)
+      );
+      level = level - 1;
+      html += '</div>';
+    } else if (item.file) {
+       await insert_one_file(item.file); 
+    } else if (item.url) {
+      html += `<button class="jp-Button toc-button tb-level${level}" style="display:block;"><a class="toc-link tb-level${level}" href="${item.url}" target="_blank" rel="noopener noreferrer" style="display: block;">${item.title}</a></button>`;
+    } else if (item.glob) {
+      const files = await jbtoc.globFiles(`${cwd}${item.glob}`);
+      for (const file of files) {
+        const relative = file.replace(`${cwd}`, '');
+        await insert_one_file(relative);
+      }
+    }
+  }
+  return html;
 }
 
 export async function mystTOCToHtml(project: IMystProject, cwd: string): Promise<string> {
   let html = '\n<ul>';
 
-  for (const item of project.toc) {
-    console.log(item);
-    if (item.title) {
-        html += `\n<p class="caption" role="heading"><span class="caption-text"><b>\n${item.title}\n</b></span>\n</p>`;
-    }
-} 
+//   for (const item of project.toc) {
+//     console.log(item);
+//     if (item.title) {
+//         // html += `\n<p class="caption" role="heading"><span class="caption-text"><b>\n${item.title}\n</b></span>\n</p>`;
+//         console.log(item.title);
+//     }
+//     if (item.children) {
+//         console.log(item.children);
+//     }
+//   }
+  const subISectionHtml = await getSubSection(project.toc, cwd);
+  html += `\n${subISectionHtml}`;
+
 //   if (toc.parts) {
 //     for (const chapter of toc.parts) {
 //       html += `\n<p class="caption" role="heading"><span class="caption-text"><b>\n${chapter.caption}\n</b></span>\n</p>`;

--- a/src/jb2.ts
+++ b/src/jb2.ts
@@ -95,12 +95,13 @@ export async function mystTOCToHtml(
 
   for (const item of toc) {
     console.log(item);
-    if (item.title && item.children) {
+    if ((item.title || item.file) && item.children) {
+      
       // If there are a title, children, and a file, use the file path as the title   
       if (item.file) {
         await insert_one_file(item.file, true);
       }
-      else {
+      else if (item.title){
         insert_title(item.title);
       }
       const html_cur = html;

--- a/src/jb2.ts
+++ b/src/jb2.ts
@@ -74,13 +74,26 @@ export async function mystTOCToHtml(
   }
 
   for (const item of toc) {
+    let file = '';
+    if (item.file) {
+      file = jbtoc.escapeHtml(String(item.file));
+    }
+    let title = '';
+    if (item.title) {
+      title = jbtoc.escapeHtml(String(item.title));
+    }
+    let url = '';
+    if (item.url) {
+      url = jbtoc.escapeHtml(String(item.url));
+    }
+
     console.log(item);
     if ((item.title || item.file) && item.children) {
       // If there are a title, children, and a file, use the file path as the title
       if (item.file) {
-        await insertFile(item.file, true);
+        await insertFile(file, true);
       } else if (item.title) {
-        insertMystTitle(item.title);
+        insertMystTitle(title);
       }
       const html_cur = html;
       html = await mystTOCToHtml(
@@ -92,9 +105,10 @@ export async function mystTOCToHtml(
       level = level - 1;
       html += '</div>';
     } else if (item.file) {
-      await insertFile(item.file);
-    } else if (item.url) {
-      html += `<button class="jp-Button toc-button tb-level${level}" style="display:block;"><a class="toc-link tb-level${level}" href="${item.url}" target="_blank" rel="noopener noreferrer" style="display: block;">${item.title}</a></button>`;
+      await insertFile(file);
+    } else if (item.url && item.title) {
+      html += `<button class="jp-Button toc-button tb-level${level}" style="display:block;"><a class="toc-link tb-level${level}" 
+      href="${url}" target="_blank" rel="noopener noreferrer" style="display: block;">${title}</a></button>`;
     } else if (item.glob) {
       const files = await jbtoc.globFiles(`${cwd}${item.glob}`);
       for (const file of files) {
@@ -113,12 +127,15 @@ export async function getHtmlTop(
   let html_top = `<div class="jbook-toc" data-toc-dir="${configParent}">`;
 
   if (project.title) {
-    html_top += `<p id="toc-title">${project.title}</p>`;
+    html_top += `<p id="toc-title">${jbtoc.escapeHtml(String(project.title))}</p>`;
   }
   if (project.subtitle) {
-    html_top += `<p id="toc-subtitle">${project.subtitle}</p>`;
+    html_top += `<p id="toc-subtitle">${jbtoc.escapeHtml(String(project.subtitle))}</p>`;
   }
   html_top += '<br><hr class="toc-hr">';
+  
+  console.log(html_top);
+  
   return html_top;
 }
 
@@ -133,10 +150,10 @@ export async function getHtmlBottom(project: MystProject): Promise<string> {
       html_bottom += '<p id="toc-author">Authors: ';
     }
     authors.forEach((author, i) => {
-      if (i < authors.length - 1) {
-        html_bottom += `${author.name}, `;
-      } else {
-        html_bottom += `${author.name}`;
+      if (i < authors.length - 1 && author.name) {
+        html_bottom += `${jbtoc.escapeHtml(String(author.name))}, `;
+      } else if (author.name) {
+        html_bottom += `${jbtoc.escapeHtml(String(author.name))}`;
       }
     });
     html_bottom += '</p>';
@@ -146,31 +163,34 @@ export async function getHtmlBottom(project: MystProject): Promise<string> {
     html_bottom += '<div class="badges">';
   }
   if (project.github) {
+    const github = jbtoc.escapeHtml(String(project.github));
     html_bottom += `
-      <a href="https://github.com/${project.github}" target="_blank" rel="noopener">
+      <a href="https://github.com/${github}" target="_blank" rel="noopener">
         <img
           src="https://img.shields.io/badge/GitHub-5c5c5c?logo=github"
-          alt="GitHub: ${project.github}"
+          alt="GitHub: ${github}"
         >
       </a>
     `;
   }
   if (project.license) {
+    const license = jbtoc.escapeHtml(String(project.license));
     html_bottom += `
-    <a href="https://opensource.org/licenses/${project.license}" target="_blank" rel="noopener">
+    <a href="https://opensource.org/licenses/${license}" target="_blank" rel="noopener">
       <img
-        src="https://img.shields.io/badge/License-${project.license.replaceAll('-', '_')}--Clause-blue.svg"
-        alt="License: ${project.license}"
+        src="https://img.shields.io/badge/License-${license.replaceAll('-', '_')}--Clause-blue.svg"
+        alt="License: ${license}"
       >
     </a>
     `;
   }
   if (project.doi) {
+    const doi = jbtoc.escapeHtml(String(project.doi));
     html_bottom += `
-      <a href="https://doi.org/10.5281/zenodo.${project.doi}" target="_blank" rel="noopener">
+      <a href="https://doi.org/10.5281/zenodo.${doi}" target="_blank" rel="noopener">
         <img
-          src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.${project.doi}-blue.svg"
-          alt="DOI: 10.5281/zenodo.${project.doi}"
+          src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.${doi}-blue.svg"
+          alt="DOI: 10.5281/zenodo.${doi}"
         >
       </a>
     `;
@@ -180,8 +200,11 @@ export async function getHtmlBottom(project: MystProject): Promise<string> {
   }
   if (project.copyright) {
     html_bottom += `
-      <p style="padding-left: 15px">Copyright © ${project.copyright}</p>
+      <p style="padding-left: 15px">Copyright © ${jbtoc.escapeHtml(String(project.copyright))}</p>
     `;
   }
+
+  console.log(html_bottom);
+
   return html_bottom;
 }

--- a/src/jb2.ts
+++ b/src/jb2.ts
@@ -6,7 +6,6 @@ export interface Myst {
 export interface MystProject {
   title?: string;
   subtitle?: string;
-  downloads?: MystDownload[];
   authors?: MystAuthors[];
   doi?: string;
   github?: string;
@@ -126,19 +125,19 @@ export async function getHtmlTop(
   if (project.subtitle) {
     html_top += `<p id="toc-subtitle">${project.subtitle}</p>`;
   }
-  html_top += `<br><hr class=toc-hr>`;
+  html_top += '<br><hr class="toc-hr">';
   return html_top;
 }
 
 export async function getHtmlBottom(project: MystProject): Promise<string> {
-  let html_bottom = `<br><hr class=toc-hr><br>`;
+  let html_bottom = '<br><hr class="toc-hr"><br>';
 
   if (project.authors) {
     const authors = project.authors;
-    if (authors.length == 1) {
-      html_bottom += `<p id="toc-author">Author: `;
+    if (authors.length === 1) {
+      html_bottom += '<p id="toc-author">Author: ';
     } else {
-      html_bottom += `<p id="toc-author">Authors: `;
+      html_bottom += '<p id="toc-author">Authors: ';
     }
     authors.forEach((author, i) => {
       if (i < authors.length - 1) {
@@ -147,11 +146,11 @@ export async function getHtmlBottom(project: MystProject): Promise<string> {
         html_bottom += `${author.name}`;
       }
     });
-    html_bottom += `</p>`;
+    html_bottom += '</p>';
   }
 
   if (project.github || project.license || project.doi) {
-    html_bottom += `<div class=badges>`;
+    html_bottom += '<div class="badges">';
   }
   if (project.github) {
     html_bottom += `
@@ -184,7 +183,7 @@ export async function getHtmlBottom(project: MystProject): Promise<string> {
     `;
   }
   if (project.github || project.license || project.doi) {
-    html_bottom += `</div>`;
+    html_bottom += '</div>';
   }
   if (project.copyright) {
     html_bottom += `

--- a/src/jb2.ts
+++ b/src/jb2.ts
@@ -79,7 +79,7 @@ export async function mystTOCToHtml(
     return file_html;
   }
 
-  async function insertMystTitle(htmlTitle: string, attrTitle: string,) {
+  async function insertMystTitle(htmlTitle: string, attrTitle: string) {
     const sectionId = `sec-${Math.random().toString(36).slice(2)}`;
 
     return `

--- a/src/jb2.ts
+++ b/src/jb2.ts
@@ -37,13 +37,16 @@ export async function mystTOCToHtml(
     const k_dir = parts.join('/');
     let pth = await jbtoc.getFullPath(file, `${cwd}${k_dir}`);
     pth = jbtoc.escAttr(String(pth));
-    let title = await jbtoc.getFileTitleFromHeader(pth);
-    title = jbtoc.escHtml(String(title));
-    const sectionId = `sec-${Math.random().toString(36).slice(2)}`;
 
+    let title = await jbtoc.getFileTitleFromHeader(pth);
     if (!title) {
       title = file;
     }
+    const htmlTitle = jbtoc.escHtml(String(title));
+    const attrTitle = jbtoc.escAttr(String(title));
+
+    const sectionId = `sec-${Math.random().toString(36).slice(2)}`;
+
     let file_html;
     if (chevron) {
       file_html = `<div class="toc-row">
@@ -51,15 +54,15 @@ export async function mystTOCToHtml(
           type="button"
           class="jp-Button toc-button tb-level${level} toc-file"
           data-file-path="${pth}"
-          aria-label="Open ${title}"
-        ><b>${title}</b></button>
+          aria-label="Open ${attrTitle}"
+        ><b>${htmlTitle}</b></button>
 
         <button
           type="button"
           class="jp-Button toc-chevron"
           aria-expanded="false"
           aria-controls="${sectionId}"
-          aria-label="Toggle section for ${title}"
+          aria-label="Toggle section for ${attrTitle}"
         ><i class="fa fa-chevron-down"></i></button>
       </div>
       <div id="${sectionId}" class="toc-children" hidden>
@@ -68,9 +71,9 @@ export async function mystTOCToHtml(
       file_html = `<button
         class="jp-Button toc-button tb-level${level}"
         data-file-path="${pth}"
-        aria-label="Open ${title}"
+        aria-label="Open ${attrTitle}"
       >
-        ${title}
+        ${htmlTitle}
       </button>`;
     }
     return file_html;

--- a/src/jb2.ts
+++ b/src/jb2.ts
@@ -79,14 +79,13 @@ export async function mystTOCToHtml(
     return file_html;
   }
 
-  async function insertMystTitle(title: string) {
+  async function insertMystTitle(htmlTitle: string, attrTitle: string,) {
     const sectionId = `sec-${Math.random().toString(36).slice(2)}`;
-    const attrTitle = jbtoc.escAttr(title);
 
     return `
       <div class="toc-row">
         <p class="caption tb-level${level}" role="heading" aria-level="${level}">
-          <b>${title}</b>
+          <b>${htmlTitle}</b>
         </p>
         <button
           type="button"
@@ -101,7 +100,7 @@ export async function mystTOCToHtml(
     `;
   }
 
-  async function insertUrl(title: string, url: string) {
+  async function insertUrl(htmlTitle: string, attrTitle: string, url: string) {
     return `
     <div class="toc-row">
       <a
@@ -109,9 +108,9 @@ export async function mystTOCToHtml(
         href="${url}"
         target="_blank"
         rel="noopener noreferrer"
-        aria-label="Open external link to ${title}"
+        aria-label="Open external link to ${attrTitle}"
       >
-        ${title}
+        ${htmlTitle}
       </a>
     </div>
     `;
@@ -124,21 +123,22 @@ export async function mystTOCToHtml(
   const html_snippets: string[] = [];
   for (const item of toc) {
     const file = item.file ? jbtoc.escAttr(encodeURI(String(item.file))) : '';
-    const title = item.title ? jbtoc.escHtml(String(item.title)) : '';
+    const htmlTitle = item.title ? jbtoc.escHtml(String(item.title)) : '';
+    const attrTitle = item.title ? jbtoc.escAttr(String(item.title)) : '';
     const url = item.url ? jbtoc.escAttr(encodeURI(String(item.url))) : '';
 
     if ((item.title || item.file) && item.children) {
       if (item.file) {
         html_snippets.push(await insertFile(file, true));
       } else if (item.title) {
-        html_snippets.push(await insertMystTitle(title));
+        html_snippets.push(await insertMystTitle(htmlTitle, attrTitle));
       }
       html_snippets.push(await mystTOCToHtml(item.children, cwd, level + 1));
       html_snippets.push('</div>');
     } else if (item.file) {
       html_snippets.push(await insertFile(file));
     } else if (item.url && item.title) {
-      html_snippets.push(await insertUrl(title, url));
+      html_snippets.push(await insertUrl(htmlTitle, attrTitle, url));
     } else if (item.glob) {
       const files = await jbtoc.globFiles(`${cwd}${item.glob}`);
       for (const file of files) {

--- a/src/jb2.ts
+++ b/src/jb2.ts
@@ -36,7 +36,6 @@ export async function mystTOCToHtml(
     parts.pop();
     const k_dir = parts.join('/');
     let pth = await jbtoc.getFullPath(file, `${cwd}${k_dir}`);
-    // pth = jbtoc.escAttr(String(pth));
 
     let title = await jbtoc.getFileTitleFromHeader(String(pth));
     if (!title) {
@@ -122,21 +121,21 @@ export async function mystTOCToHtml(
 
   const html_snippets: string[] = [];
   for (const item of toc) {
-    const file = item.file ? jbtoc.escAttr(encodeURI(String(item.file))) : '';
+    // const file = item.file ? jbtoc.escAttr(encodeURI(String(item.file))) : '';
     const htmlTitle = item.title ? jbtoc.escHtml(String(item.title)) : '';
     const attrTitle = item.title ? jbtoc.escAttr(String(item.title)) : '';
     const url = item.url ? jbtoc.escAttr(encodeURI(String(item.url))) : '';
 
     if ((item.title || item.file) && item.children) {
       if (item.file) {
-        html_snippets.push(await insertFile(file, true));
+        html_snippets.push(await insertFile(item.file, true));
       } else if (item.title) {
         html_snippets.push(await insertMystTitle(htmlTitle, attrTitle));
       }
       html_snippets.push(await mystTOCToHtml(item.children, cwd, level + 1));
       html_snippets.push('</div>');
     } else if (item.file) {
-      html_snippets.push(await insertFile(file));
+      html_snippets.push(await insertFile(item.file));
     } else if (item.url && item.title) {
       html_snippets.push(await insertUrl(htmlTitle, attrTitle, url));
     } else if (item.glob) {

--- a/src/jb2.ts
+++ b/src/jb2.ts
@@ -36,9 +36,9 @@ export async function mystTOCToHtml(
     parts.pop();
     const k_dir = parts.join('/');
     let pth = await jbtoc.getFullPath(file, `${cwd}${k_dir}`);
-    pth = jbtoc.escAttr(String(pth));
+    // pth = jbtoc.escAttr(String(pth));
 
-    let title = await jbtoc.getFileTitleFromHeader(pth);
+    let title = await jbtoc.getFileTitleFromHeader(String(pth));
     if (!title) {
       title = file;
     }

--- a/src/jb2.ts
+++ b/src/jb2.ts
@@ -1,0 +1,64 @@
+export interface IMyst {
+  project?: IMystProject;
+}
+
+export interface IMystProject {
+  title?: string;
+  subtitle?: string;
+  short_title?: string;
+  description?: string;
+  downloads?: IMystDownload[];
+  authors?: string[];
+  reviewers?: string[];
+  editors?: string[];
+  affliliations?: string[];
+  doi?: string;
+  github?: string;
+  arxiv?: string;
+  pmid?: string;
+  open_access?: string;
+  license?: string;
+  copyright?: string;
+  social?: string
+  toc: IMystTOC[];
+}
+
+
+
+interface IMystDownload {
+  file?: string;
+  title?: string;
+  url?: string;
+  filename?: string;
+}
+
+export interface IMystTOC {
+  file?: string;
+  title?: string;
+  children?: IMystTOC[];
+}
+
+export async function mystTOCToHtml(project: IMystProject, cwd: string): Promise<string> {
+  let html = '\n<ul>';
+
+  for (const item of project.toc) {
+    console.log(item);
+    if (item.title) {
+        html += `\n<p class="caption" role="heading"><span class="caption-text"><b>\n${item.title}\n</b></span>\n</p>`;
+    }
+} 
+//   if (toc.parts) {
+//     for (const chapter of toc.parts) {
+//       html += `\n<p class="caption" role="heading"><span class="caption-text"><b>\n${chapter.caption}\n</b></span>\n</p>`;
+//       const subISectionHtml = await getSubSection(chapter.chapters, cwd);
+//       html += `\n${subISectionHtml}`;
+//     }
+//   } else {
+//     if (toc.chapters) {
+//       const subISectionHtml = await getSubSection(toc.chapters, cwd);
+//       html += `\n${subISectionHtml}`;
+//     }
+//   }
+//   html += '\n</ul>';
+  return html;
+}

--- a/src/jb2.ts
+++ b/src/jb2.ts
@@ -131,7 +131,7 @@ export async function getHtmlTop(
   if (project.subtitle) {
     html_top += `<p id="toc-subtitle">${jbtoc.escapeHtml(String(project.subtitle))}</p>`;
   }
-  html_top += '<br><hr class="toc-hr">';  
+  html_top += '<br><hr class="toc-hr">';
   return html_top;
 }
 

--- a/src/jb2.ts
+++ b/src/jb2.ts
@@ -13,7 +13,7 @@ export interface IMystProject {
   short_title?: string;
   description?: string;
   downloads?: IMystDownload[];
-  authors?: string[];
+  authors?: IMystAuthors[];
   reviewers?: string[];
   editors?: string[];
   affliliations?: string[];
@@ -25,7 +25,9 @@ export interface IMystProject {
   toc: IMystTOC[];
 }
 
-
+interface IMystAuthors {
+    name?: string;
+}
 
 interface IMystDownload {
   file?: string;
@@ -42,7 +44,7 @@ export interface IMystTOC {
   glob?: string;
 }
 
-async function getSubSection(
+export async function mystTOCToHtml(
   toc: IMystTOC[],
   cwd: string,
   level: number = 1,
@@ -63,8 +65,12 @@ async function getSubSection(
     }
     if (chevron) {
       html += `
-        <div>
-            <button class="jp-Button toc-button tb-level${level}"style="display: inline-block;" data-file-path="${pth}">${title}</button>
+        <div style="display: flex; align-items: center;">
+            <button class="jp-Button toc-button tb-level${level}"
+                    style="display: inline-block; font-weight: bold"
+                    data-file-path="${pth}">
+              ${title}
+            </button>
             <button class="jp-Button toc-chevron" style="display: inline-block;"><i class="fa fa-chevron-down "></i></button>
         </div>
         <div style="display: none;">
@@ -78,7 +84,7 @@ async function getSubSection(
   async function insert_title(title: string) {
 
     html += `
-    <div style="display: flex; align-items: center; justify-content: space-between;">
+    <div style="display: flex; align-items: center;">
         <p class="caption tb-level${level}" role="heading" style="margin: 0;">
         <span class="caption-text"><b>${title}</b></span></p>
         <button class="jp-Button toc-chevron" style="display: inline-block;"><i class="fa fa-chevron-down "></i></button>
@@ -90,7 +96,7 @@ async function getSubSection(
   for (const item of toc) {
     console.log(item);
     if (item.title && item.children) {
-      // If there are a title, children, and a file, use the file as the title   
+      // If there are a title, children, and a file, use the file path as the title   
       if (item.file) {
         await insert_one_file(item.file, true);
       }
@@ -98,7 +104,7 @@ async function getSubSection(
         insert_title(item.title);
       }
       const html_cur = html;
-      html = await getSubSection(
+      html = await mystTOCToHtml(
         item.children,
         cwd,
         (level = level + 1),
@@ -118,37 +124,5 @@ async function getSubSection(
       }
     }
   }
-  return html;
-}
-
-export async function mystTOCToHtml(project: IMystProject, cwd: string): Promise<string> {
-  let html = '\n<ul>';
-
-//   for (const item of project.toc) {
-//     console.log(item);
-//     if (item.title) {
-//         // html += `\n<p class="caption" role="heading"><span class="caption-text"><b>\n${item.title}\n</b></span>\n</p>`;
-//         console.log(item.title);
-//     }
-//     if (item.children) {
-//         console.log(item.children);
-//     }
-//   }
-  const subISectionHtml = await getSubSection(project.toc, cwd);
-  html += `\n${subISectionHtml}`;
-
-//   if (toc.parts) {
-//     for (const chapter of toc.parts) {
-//       html += `\n<p class="caption" role="heading"><span class="caption-text"><b>\n${chapter.caption}\n</b></span>\n</p>`;
-//       const subISectionHtml = await getSubSection(chapter.chapters, cwd);
-//       html += `\n${subISectionHtml}`;
-//     }
-//   } else {
-//     if (toc.chapters) {
-//       const subISectionHtml = await getSubSection(toc.chapters, cwd);
-//       html += `\n${subISectionHtml}`;
-//     }
-//   }
-//   html += '\n</ul>';
   return html;
 }

--- a/src/jb2.ts
+++ b/src/jb2.ts
@@ -18,13 +18,6 @@ interface MystAuthors {
   name?: string;
 }
 
-interface MystDownload {
-  file?: string;
-  title?: string;
-  url?: string;
-  filename?: string;
-}
-
 export interface MystTOC {
   file?: string;
   title?: string;

--- a/src/jb2.ts
+++ b/src/jb2.ts
@@ -139,58 +139,6 @@ export async function getHtmlTop(
   if (project.subtitle) {
     html_top += `<p id="toc-subtitle">${project.subtitle}</p>`
   }
-  if (project.authors) {
-    const authors = project.authors;
-    if (authors.length == 1) {
-      html_top += `<p id="toc-author">Author: `
-    } else {
-      html_top += `<p id="toc-author">Authors: `
-    }
-    authors.forEach((author, i) => {
-      if (i < authors.length - 1) {
-        html_top += `${author.name}, `
-      } else {
-        html_top += `${author.name}`
-      }
-    });
-    html_top += `</p>`
-  }
-  // if (project.github || project.license || project.doi) {
-  //   html_top += `<div class=badges>`
-  // }
-  // if (project.github) {
-  //   html_top += `
-  //     <a href="https://github.com/${project.github}" target="_blank" rel="noopener">
-  //       <img
-  //         src="https://img.shields.io/badge/GitHub-5c5c5c?logo=github"
-  //         alt="GitHub: ${project.github}"
-  //       >
-  //     </a>
-  //   `
-  // }
-  // if (project.license) {
-  //   html_top +=`
-  //   <a href="https://opensource.org/licenses/${project.license}" target="_blank" rel="noopener">
-  //     <img
-  //       src="https://img.shields.io/badge/License-${project.license.replaceAll("-", "_")}--Clause-blue.svg"
-  //       alt="License: ${project.license}"
-  //     >
-  //   </a>
-  //   `
-  // }
-  // if (project.doi) {
-  //   html_top += `
-  //     <a href="https://doi.org/10.5281/zenodo.${project.doi}" target="_blank" rel="noopener">
-  //       <img
-  //         src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.${project.doi}-blue.svg"
-  //         alt="DOI: 10.5281/zenodo.${project.doi}"
-  //       >
-  //     </a>
-  //   `
-  // }
-  // if (project.github || project.license || project.doi) {
-  //   html_top += `</div>`
-  // }
   html_top += `<br><hr class=toc-hr>`
   return html_top;
 }
@@ -199,6 +147,23 @@ export async function getHtmlBottom(
   project: IMystProject
 ): Promise<string> {
   let html_bottom = `<br><hr class=toc-hr><br>`
+
+   if (project.authors) {
+    const authors = project.authors;
+    if (authors.length == 1) {
+      html_bottom += `<p id="toc-author">Author: `
+    } else {
+      html_bottom += `<p id="toc-author">Authors: `
+    }
+    authors.forEach((author, i) => {
+      if (i < authors.length - 1) {
+        html_bottom += `${author.name}, `
+      } else {
+        html_bottom += `${author.name}`
+      }
+    });
+    html_bottom += `</p>`
+  }
 
   if (project.github || project.license || project.doi) {
     html_bottom += `<div class=badges>`

--- a/src/jb2.ts
+++ b/src/jb2.ts
@@ -167,7 +167,7 @@ export async function getHtmlTop(
 }
 
 export async function getHtmlBottom(project: MystProject): Promise<string> {
-  function getDOIUrl(doi: string) {
+  function getDOIHtml(doi: string) {
     if (!doi) {
       return '';
     }
@@ -197,6 +197,43 @@ export async function getHtmlBottom(project: MystProject): Promise<string> {
   </a>`;
   }
 
+  function getGithubHtml(github: string) {
+    let githubUrl: string;
+    let githubLabel: string;
+
+    const githubValue = String(github).trim();
+
+    if (
+      githubValue.startsWith('http://') ||
+      githubValue.startsWith('https://')
+    ) {
+      githubUrl = githubValue;
+      const match = githubValue.match(/github\.com\/([^/]+\/[^/]+)/);
+      githubLabel = match ? match[1] : githubValue;
+    } else {
+      githubLabel = githubValue;
+      githubUrl = `https://github.com/${githubValue}`;
+    }
+
+    const githubEscaped = jbtoc.escAttr(encodeURI(githubLabel));
+
+    return `
+      <a
+        href="${githubUrl}"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="toc-link github-link"
+        aria-label="Open GitHub repository ${githubEscaped} (opens in a new tab)"
+      >
+        <img
+          src="https://img.shields.io/badge/GitHub-5c5c5c?logo=github"
+          alt="GitHub badge for ${githubEscaped}"
+          loading="lazy"
+        >
+      </a>
+    `;
+  }
+
   let html_bottom = '<br><hr class="toc-hr"><br>';
 
   if (Array.isArray(project.authors) && project.authors.length) {
@@ -215,22 +252,7 @@ export async function getHtmlBottom(project: MystProject): Promise<string> {
   }
 
   if (project.github) {
-    const github = jbtoc.escAttr(encodeURI(String(project.github)));
-    html_bottom += `
-      <a
-        href="https://github.com/${github}"
-        target="_blank"
-        rel="noopener noreferrer"
-        class="toc-link github-link"
-        aria-label="Open GitHub repository ${github} (opens in a new tab)"
-      >
-        <img
-          src="https://img.shields.io/badge/GitHub-5c5c5c?logo=github"
-          alt="GitHub badge for ${github}"
-          loading="lazy"
-        >
-      </a>   
-    `;
+    html_bottom += getGithubHtml(project.github);
   }
 
   if (project.license) {
@@ -253,7 +275,7 @@ export async function getHtmlBottom(project: MystProject): Promise<string> {
   }
 
   if (project.doi) {
-    html_bottom += getDOIUrl(project.doi);
+    html_bottom += getDOIHtml(project.doi);
   }
 
   if (project.github || project.license || project.doi) {

--- a/src/jb2.ts
+++ b/src/jb2.ts
@@ -26,11 +26,103 @@ export interface MystTOC {
   glob?: string;
 }
 
+// export async function mystTOCToHtml(
+//   toc: MystTOC[],
+//   cwd: string,
+//   level: number = 1,
+//   html: string = ''
+// ): Promise<string> {
+//   if (cwd && cwd.slice(-1) !== '/') {
+//     cwd = cwd + '/';
+//   }
+
+//   async function insertFile(file: string, chevron: boolean = false) {
+//     const parts = file.split('/');
+//     parts.pop();
+//     const k_dir = parts.join('/');
+//     const pth = await jbtoc.getFullPath(file, `${cwd}${k_dir}`);
+//     let title = await jbtoc.getFileTitleFromHeader(pth);
+//     if (!title) {
+//       title = file;
+//     }
+//     if (chevron) {
+//       html += `
+//         <div style="display: flex; align-items: center;">
+//             <button class="jp-Button toc-button tb-level${level}"
+//                     style="display: inline-block; font-weight: bold"
+//                     data-file-path="${pth}">
+//               ${title}
+//             </button>
+//             <button class="jp-Button toc-chevron" style="display: inline-block;"><i class="fa fa-chevron-down "></i></button>
+//         </div>
+//         <div style="display: none;">
+//         `;
+//     } else {
+//       html += `<button class="jp-Button toc-button tb-level${level}" style="display: block;" data-file-path="${pth}">${title}</button>`;
+//     }
+//   }
+
+//   async function insertMystTitle(title: string) {
+//     html += `
+//     <div style="display: flex; align-items: center;">
+//         <p class="caption tb-level${level}" role="heading" style="margin: 0;">
+//         <span class="caption-text"><b>${title}</b></span></p>
+//         <button class="jp-Button toc-chevron" style="display: inline-block;"><i class="fa fa-chevron-down "></i></button>
+//     </div>
+//     <div style="display: none;">
+//     `;
+//   }
+
+//   for (const item of toc) {
+//     let file = '';
+//     if (item.file) {
+//       file = jbtoc.escapeHtml(String(item.file));
+//     }
+//     let title = '';
+//     if (item.title) {
+//       title = jbtoc.escapeHtml(String(item.title));
+//     }
+//     let url = '';
+//     if (item.url) {
+//       url = jbtoc.escapeHtml(String(item.url));
+//     }
+
+//     if ((item.title || item.file) && item.children) {
+//       // If there are a title, children, and a file, use the file path as the title
+//       if (item.file) {
+//         await insertFile(file, true);
+//       } else if (item.title) {
+//         insertMystTitle(title);
+//       }
+//       const html_cur = html;
+//       html = await mystTOCToHtml(
+//         item.children,
+//         cwd,
+//         (level = level + 1),
+//         (html = html_cur)
+//       );
+//       level = level - 1;
+//       html += '</div>';
+//     } else if (item.file) {
+//       await insertFile(file);
+//     } else if (item.url && item.title) {
+//       html += `<button class="jp-Button toc-button tb-level${level}" style="display:block;"><a class="toc-link tb-level${level}" 
+//       href="${url}" target="_blank" rel="noopener noreferrer" style="display: block;">${title}</a></button>`;
+//     } else if (item.glob) {
+//       const files = await jbtoc.globFiles(`${cwd}${item.glob}`);
+//       for (const file of files) {
+//         const relative = file.replace(`${cwd}`, '');
+//         await insertFile(relative);
+//       }
+//     }
+//   }
+//   return html;
+// }
+
 export async function mystTOCToHtml(
   toc: MystTOC[],
   cwd: string,
   level: number = 1,
-  html: string = ''
 ): Promise<string> {
   if (cwd && cwd.slice(-1) !== '/') {
     cwd = cwd + '/';
@@ -45,8 +137,9 @@ export async function mystTOCToHtml(
     if (!title) {
       title = file;
     }
+    let file_html;
     if (chevron) {
-      html += `
+      file_html = `
         <div style="display: flex; align-items: center;">
             <button class="jp-Button toc-button tb-level${level}"
                     style="display: inline-block; font-weight: bold"
@@ -58,12 +151,13 @@ export async function mystTOCToHtml(
         <div style="display: none;">
         `;
     } else {
-      html += `<button class="jp-Button toc-button tb-level${level}" style="display: block;" data-file-path="${pth}">${title}</button>`;
+      file_html = `<button class="jp-Button toc-button tb-level${level}" style="display: block;" data-file-path="${pth}">${title}</button>`;
     }
+    return file_html
   }
 
   async function insertMystTitle(title: string) {
-    html += `
+    return `
     <div style="display: flex; align-items: center;">
         <p class="caption tb-level${level}" role="heading" style="margin: 0;">
         <span class="caption-text"><b>${title}</b></span></p>
@@ -73,50 +167,42 @@ export async function mystTOCToHtml(
     `;
   }
 
+  async function insertUrl(title: string, url: string) {
+    return `<button class="jp-Button toc-button tb-level${level}" style="display:block;"><a class="toc-link tb-level${level}" 
+      href="${url}" target="_blank" rel="noopener noreferrer" style="display: block;">${title}</a></button>`;
+  }
+
+  const html_snippets: string[] = [];
   for (const item of toc) {
-    let file = '';
-    if (item.file) {
-      file = jbtoc.escapeHtml(String(item.file));
-    }
-    let title = '';
-    if (item.title) {
-      title = jbtoc.escapeHtml(String(item.title));
-    }
-    let url = '';
-    if (item.url) {
-      url = jbtoc.escapeHtml(String(item.url));
-    }
+    const file = item.file ? jbtoc.escAttr(encodeURI(String(item.file))) : '';
+    const title = item.title ? jbtoc.escHtml(String(item.title)) : '';
+    const url = item.url ? jbtoc.escAttr(encodeURI(String(item.url))) : '';
 
     if ((item.title || item.file) && item.children) {
-      // If there are a title, children, and a file, use the file path as the title
       if (item.file) {
-        await insertFile(file, true);
+        html_snippets.push(await insertFile(file, true));
       } else if (item.title) {
-        insertMystTitle(title);
+        html_snippets.push(await insertMystTitle(title));
       }
-      const html_cur = html;
-      html = await mystTOCToHtml(
+      html_snippets.push(await mystTOCToHtml(
         item.children,
         cwd,
-        (level = level + 1),
-        (html = html_cur)
-      );
-      level = level - 1;
-      html += '</div>';
+        level+1,
+      ));
+      html_snippets.push('</div>');
     } else if (item.file) {
-      await insertFile(file);
+      html_snippets.push(await insertFile(file));
     } else if (item.url && item.title) {
-      html += `<button class="jp-Button toc-button tb-level${level}" style="display:block;"><a class="toc-link tb-level${level}" 
-      href="${url}" target="_blank" rel="noopener noreferrer" style="display: block;">${title}</a></button>`;
+      html_snippets.push(await insertUrl(title, url));
     } else if (item.glob) {
       const files = await jbtoc.globFiles(`${cwd}${item.glob}`);
       for (const file of files) {
         const relative = file.replace(`${cwd}`, '');
-        await insertFile(relative);
+        html_snippets.push(await insertFile(relative));
       }
     }
   }
-  return html;
+  return html_snippets.join("");
 }
 
 export async function getHtmlTop(
@@ -126,10 +212,10 @@ export async function getHtmlTop(
   let html_top = `<div class="jbook-toc" data-toc-dir="${configParent}">`;
 
   if (project.title) {
-    html_top += `<p id="toc-title">${jbtoc.escapeHtml(String(project.title))}</p>`;
+    html_top += `<p id="toc-title">${jbtoc.escHtml(String(project.title))}</p>`;
   }
   if (project.subtitle) {
-    html_top += `<p id="toc-subtitle">${jbtoc.escapeHtml(String(project.subtitle))}</p>`;
+    html_top += `<p id="toc-subtitle">${jbtoc.escHtml(String(project.subtitle))}</p>`;
   }
   html_top += '<br><hr class="toc-hr">';
   return html_top;
@@ -147,9 +233,9 @@ export async function getHtmlBottom(project: MystProject): Promise<string> {
     }
     authors.forEach((author, i) => {
       if (i < authors.length - 1 && author.name) {
-        html_bottom += `${jbtoc.escapeHtml(String(author.name))}, `;
+        html_bottom += `${jbtoc.escHtml(String(author.name))}, `;
       } else if (author.name) {
-        html_bottom += `${jbtoc.escapeHtml(String(author.name))}`;
+        html_bottom += `${jbtoc.escHtml(String(author.name))}`;
       }
     });
     html_bottom += '</p>';
@@ -159,7 +245,7 @@ export async function getHtmlBottom(project: MystProject): Promise<string> {
     html_bottom += '<div class="badges">';
   }
   if (project.github) {
-    const github = jbtoc.escapeHtml(String(project.github));
+    const github = jbtoc.escAttr(encodeURI(String(project.github)));
     html_bottom += `
       <a href="https://github.com/${github}" target="_blank" rel="noopener">
         <img
@@ -170,7 +256,7 @@ export async function getHtmlBottom(project: MystProject): Promise<string> {
     `;
   }
   if (project.license) {
-    const license = jbtoc.escapeHtml(String(project.license));
+    const license = jbtoc.escHtml(String(project.license));
     html_bottom += `
     <a href="https://opensource.org/licenses/${license}" target="_blank" rel="noopener">
       <img
@@ -181,7 +267,7 @@ export async function getHtmlBottom(project: MystProject): Promise<string> {
     `;
   }
   if (project.doi) {
-    const doi = jbtoc.escapeHtml(String(project.doi));
+    const doi = jbtoc.escHtml(String(project.doi));
     html_bottom += `
       <a href="https://doi.org/10.5281/zenodo.${doi}" target="_blank" rel="noopener">
         <img
@@ -196,7 +282,7 @@ export async function getHtmlBottom(project: MystProject): Promise<string> {
   }
   if (project.copyright) {
     html_bottom += `
-      <p style="padding-left: 15px">Copyright © ${jbtoc.escapeHtml(String(project.copyright))}</p>
+      <p style="padding-left: 15px">Copyright © ${jbtoc.escHtml(String(project.copyright))}</p>
     `;
   }
   return html_bottom;

--- a/src/jb2.ts
+++ b/src/jb2.ts
@@ -32,10 +32,7 @@ export async function mystTOCToHtml(
   level: number = 1
 ): Promise<string> {
   async function insertFile(file: string, chevron: boolean = false) {
-    const parts = file.split('/');
-    parts.pop();
-    const k_dir = parts.join('/');
-    let pth = await jbtoc.getFullPath(file, `${cwd}${k_dir}`);
+    const pth = await jbtoc.getFullPath(file, cwd);
 
     let title = await jbtoc.getFileTitleFromHeader(String(pth));
     if (!title) {
@@ -121,7 +118,6 @@ export async function mystTOCToHtml(
 
   const html_snippets: string[] = [];
   for (const item of toc) {
-    // const file = item.file ? jbtoc.escAttr(encodeURI(String(item.file))) : '';
     const htmlTitle = item.title ? jbtoc.escHtml(String(item.title)) : '';
     const attrTitle = item.title ? jbtoc.escAttr(String(item.title)) : '';
     const url = item.url ? jbtoc.escAttr(encodeURI(String(item.url))) : '';

--- a/src/jb2.ts
+++ b/src/jb2.ts
@@ -126,3 +126,120 @@ export async function mystTOCToHtml(
   }
   return html;
 }
+
+export async function getHtmlTop(
+  project: IMystProject,
+  configParent: string,
+): Promise<string> {
+  let html_top = `<div class="jbook-toc" data-toc-dir="${configParent}">`;
+
+  if (project.title) {
+    html_top += `<p id="toc-title">${project.title}</p>`;
+  }
+  if (project.subtitle) {
+    html_top += `<p id="toc-subtitle">${project.subtitle}</p>`
+  }
+  if (project.authors) {
+    const authors = project.authors;
+    if (authors.length == 1) {
+      html_top += `<p id="toc-author">Author: `
+    } else {
+      html_top += `<p id="toc-author">Authors: `
+    }
+    authors.forEach((author, i) => {
+      if (i < authors.length - 1) {
+        html_top += `${author.name}, `
+      } else {
+        html_top += `${author.name}`
+      }
+    });
+    html_top += `</p>`
+  }
+  // if (project.github || project.license || project.doi) {
+  //   html_top += `<div class=badges>`
+  // }
+  // if (project.github) {
+  //   html_top += `
+  //     <a href="https://github.com/${project.github}" target="_blank" rel="noopener">
+  //       <img
+  //         src="https://img.shields.io/badge/GitHub-5c5c5c?logo=github"
+  //         alt="GitHub: ${project.github}"
+  //       >
+  //     </a>
+  //   `
+  // }
+  // if (project.license) {
+  //   html_top +=`
+  //   <a href="https://opensource.org/licenses/${project.license}" target="_blank" rel="noopener">
+  //     <img
+  //       src="https://img.shields.io/badge/License-${project.license.replaceAll("-", "_")}--Clause-blue.svg"
+  //       alt="License: ${project.license}"
+  //     >
+  //   </a>
+  //   `
+  // }
+  // if (project.doi) {
+  //   html_top += `
+  //     <a href="https://doi.org/10.5281/zenodo.${project.doi}" target="_blank" rel="noopener">
+  //       <img
+  //         src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.${project.doi}-blue.svg"
+  //         alt="DOI: 10.5281/zenodo.${project.doi}"
+  //       >
+  //     </a>
+  //   `
+  // }
+  // if (project.github || project.license || project.doi) {
+  //   html_top += `</div>`
+  // }
+  html_top += `<br><hr class=toc-hr>`
+  return html_top;
+}
+
+export async function getHtmlBottom(
+  project: IMystProject
+): Promise<string> {
+  let html_bottom = `<br><hr class=toc-hr><br>`
+
+  if (project.github || project.license || project.doi) {
+    html_bottom += `<div class=badges>`
+  }
+  if (project.github) {
+    html_bottom += `
+      <a href="https://github.com/${project.github}" target="_blank" rel="noopener">
+        <img
+          src="https://img.shields.io/badge/GitHub-5c5c5c?logo=github"
+          alt="GitHub: ${project.github}"
+        >
+      </a>
+    `
+  }
+  if (project.license) {
+    html_bottom +=`
+    <a href="https://opensource.org/licenses/${project.license}" target="_blank" rel="noopener">
+      <img
+        src="https://img.shields.io/badge/License-${project.license.replaceAll("-", "_")}--Clause-blue.svg"
+        alt="License: ${project.license}"
+      >
+    </a>
+    `
+  }
+  if (project.doi) {
+    html_bottom += `
+      <a href="https://doi.org/10.5281/zenodo.${project.doi}" target="_blank" rel="noopener">
+        <img
+          src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.${project.doi}-blue.svg"
+          alt="DOI: 10.5281/zenodo.${project.doi}"
+        >
+      </a>
+    `
+  }
+  if (project.github || project.license || project.doi) {
+    html_bottom += `</div>`
+  }
+  if (project.copyright) {
+    html_bottom += `
+      <p style="padding-left: 15px">Copyright © ${project.copyright}</p>
+    `
+  }
+  return html_bottom;
+}

--- a/src/jb2.ts
+++ b/src/jb2.ts
@@ -81,6 +81,7 @@ export async function mystTOCToHtml(
 
   async function insertMystTitle(title: string) {
     const sectionId = `sec-${Math.random().toString(36).slice(2)}`;
+    const attrTitle = jbtoc.escAttr(title);
 
     return `
       <div class="toc-row">
@@ -92,7 +93,7 @@ export async function mystTOCToHtml(
           class="jp-Button toc-chevron"
           aria-expanded="false"
           aria-controls="${sectionId}"
-          aria-label="Toggle section for ${title}"
+          aria-label="Toggle section for ${attrTitle}"
         ><i class="fa fa-chevron-down"></i>
         </button>
       </div>

--- a/src/jbtoc.ts
+++ b/src/jbtoc.ts
@@ -175,13 +175,12 @@ let prettierModPromise:
 let htmlPluginPromise: Promise<any> | undefined;
 
 export async function formatHtmlForDev(html: string): Promise<string> {
-  if (process.env.NODE_ENV !== 'development') return html;
-
-  console.log(process.env.NODE_ENV);
+  if (process.env.NODE_ENV !== 'development') {
+    return html;
+  }
 
   prettierModPromise ??= import('prettier/standalone');
   htmlPluginPromise ??= import('prettier/plugins/html');
-
   const [prettierMod, htmlPlugin] = await Promise.all([
     prettierModPromise,
     htmlPluginPromise

--- a/src/jbtoc.ts
+++ b/src/jbtoc.ts
@@ -49,7 +49,7 @@ export async function ls(pth: string): Promise<any> {
 }
 
 export function escHtml(str: string): string {
-  if (str == null) {
+  if (str === null) {
     return '';
   }
   const s = String(str);
@@ -60,7 +60,7 @@ export function escHtml(str: string): string {
 }
 
 export function escAttr(str: string): string {
-  if (str == null) {
+  if (str === null) {
     return '';
   }
   const s = String(str);

--- a/src/jbtoc.ts
+++ b/src/jbtoc.ts
@@ -1,47 +1,15 @@
-import * as path from 'path';
+// import * as path from 'path';
 import * as yaml from 'js-yaml';
 import { getJupyterAppInstance } from './index';
+
+import * as jb1 from './jb1';
+import * as jb2 from './jb2';
 
 interface IFileMetadata {
   path: string;
 }
 
-interface IJbookConfig {
-  title: string;
-  author: string;
-  logo: string;
-}
-
-interface IToc {
-  parts?: IPart[];
-  chapters?: ISection[];
-  caption?: string;
-}
-
-interface ISection {
-  sections?: ISection[];
-  file?: string;
-  url?: string;
-  title?: string;
-  glob?: string;
-}
-
-interface IPart {
-  caption: string;
-  chapters: ISection[];
-}
-
-interface INotebook {
-  cells: ICell[];
-}
-
-interface ICell {
-  cell_type: 'markdown';
-  metadata: { object: any };
-  source: string;
-}
-
-async function getFileContents(path: string): Promise<string> {
+export async function getFileContents(path: string): Promise<string> {
   try {
     const app = getJupyterAppInstance();
     const data = await app.serviceManager.contents.get(path, { content: true });
@@ -56,83 +24,7 @@ async function getFileContents(path: string): Promise<string> {
   }
 }
 
-function isNotebook(obj: any): obj is INotebook {
-  return obj && typeof obj === 'object' && Array.isArray(obj.cells);
-}
-
-async function getTitle(filePath: string): Promise<string | null> {
-  const suffix = path.extname(filePath);
-  if (suffix === '.ipynb') {
-    try {
-      const jsonData: INotebook | string = await getFileContents(filePath);
-      if (isNotebook(jsonData)) {
-        const headerCells = jsonData.cells.filter(cell => {
-          if (cell.cell_type === 'markdown') {
-            const source = Array.isArray(cell.source)
-              ? cell.source.join('')
-              : cell.source;
-            return source.split('\n').some(line => line.startsWith('# '));
-          }
-          return false;
-        });
-
-        const firstHeaderCell = headerCells.length > 0 ? headerCells[0] : null;
-        if (firstHeaderCell) {
-          if (firstHeaderCell.source.split('\n')[0].slice(0, 2) === '# ') {
-            const title: string = firstHeaderCell.source
-              .split('\n')[0]
-              .slice(2);
-            return title;
-          }
-        }
-      }
-    } catch (error) {
-      console.error('Error reading or parsing notebook:', error);
-    }
-  } else if (suffix === '.md') {
-    try {
-      const md: INotebook | string = await getFileContents(filePath);
-      if (!isNotebook(md)) {
-        const lines: string[] = md.split('\n');
-        for (const line of lines) {
-          if (line.slice(0, 2) === '# ') {
-            return line.slice(2);
-          }
-        }
-      }
-    } catch (error) {
-      console.error('Error reading or parsing Markdown:', error);
-    }
-  }
-  return null;
-}
-
-function isIJbookConfig(obj: any): obj is IJbookConfig {
-  return obj && typeof obj === 'object' && obj.title && obj.author;
-}
-
-async function getBookConfig(
-  configPath: string
-): Promise<{ title: string | null; author: string | null }> {
-  try {
-    const yamlStr = await getFileContents(configPath);
-    if (typeof yamlStr === 'string') {
-      const config: unknown = yaml.load(yamlStr);
-      if (isIJbookConfig(config)) {
-        const title = config.title || 'Untitled Jupyter Book';
-        const author = config.author || 'Anonymous';
-        return { title, author };
-      } else {
-        console.error('Error: Misconfigured Jupyter Book config.');
-      }
-    }
-  } catch (error) {
-    console.error('Error reading or parsing config:', error);
-  }
-  return { title: null, author: null };
-}
-
-async function ls(pth: string): Promise<any> {
+export async function ls(pth: string): Promise<any> {
   if (pth === '') {
     pth = '/';
   }
@@ -147,184 +39,104 @@ async function ls(pth: string): Promise<any> {
   }
 }
 
-async function globFiles(pattern: string): Promise<string[]> {
-  const baseDir = '';
-  const result: string[] = [];
-
-  try {
-    const app = getJupyterAppInstance();
-    const data = await app.serviceManager.contents.get(baseDir, {
-      content: true
-    });
-    const regex = new RegExp(pattern);
-    for (const item of data.content) {
-      if (item.type === 'file' && regex.test(item.path)) {
-        result.push(item.path);
+async function findConfigInParents(cwd: string): Promise<string | null> {
+  const configPatterns: string[] = ['myst.yml', '_toc.yml'];
+  for (const configPattern of configPatterns) {
+    const dirs = cwd.split('/');
+    let counter: number = 0;
+    while (counter < 1) {
+      const pth = dirs.join('/');
+      const files = await ls(pth);
+      for (const value of Object.values(files.content)) {
+        const file = value as IFileMetadata;
+        if (file.path.includes(configPattern)) {
+          return file.path;
+        }
+      }
+      if (dirs.length === 0) {
+        counter += 1;
+      } else {
+        dirs.pop();
       }
     }
-  } catch (error) {
-    console.error(`Error globbing pattern ${pattern}`, error);
   }
-
-  return result;
-}
-
-async function findTOCinParents(cwd: string): Promise<string | null> {
-  const dirs = cwd.split('/');
-  const tocPattern: string = '_toc.yml';
-  let counter: number = 0;
-  while (counter < 1) {
-    const pth = dirs.join('/');
-    const files = await ls(pth);
-    for (const value of Object.values(files.content)) {
-      const file = value as IFileMetadata;
-
-      if (file.path.includes(tocPattern)) {
-        return file.path;
-      }
-    }
-    if (dirs.length === 0) {
-      counter += 1;
-    } else {
-      dirs.pop();
-    }
-  }
+  
   return null;
 }
 
-async function getFullPath(file_pattern: string, dir_pth: string) {
-  const files = await ls(dir_pth);
-  for (const value of Object.values(files.content)) {
-    const file = value as IFileMetadata;
-    if (file.path.includes(file_pattern)) {
-      return file.path;
-    }
-  }
-  return `Unable to locate ${file_pattern} in ${dir_pth}`;
-}
-
-async function getSubSection(
-  parts: ISection[],
-  cwd: string,
-  level: number = 1,
-  html: string = ''
-): Promise<string> {
-  if (cwd && cwd.slice(-1) !== '/') {
-    cwd = cwd + '/';
-  }
-
-  async function insert_one_file(file: string) {
-    const parts = file.split('/');
-    parts.pop();
-    const k_dir = parts.join('/');
-    const pth = await getFullPath(file, `${cwd}${k_dir}`);
-    let title = await getTitle(pth);
-    if (!title) {
-      title = file;
-    }
-    html += `<button class="jp-Button toc-button tb-level${level}" style="display: block;" data-file-path="${pth}">${title}</button>`;
-  }
-  for (const k of parts) {
-    if (k.sections && k.file) {
-      const parts = k.file.split('/');
-      parts.pop();
-      const k_dir = parts.join('/');
-      const pth = await getFullPath(k.file, `${cwd}${k_dir}`);
-      let title = await getTitle(pth);
-      if (!title) {
-        title = k.file;
-      }
-      html += `
-        <div>
-            <button class="jp-Button toc-button tb-level${level}"style="display: inline-block;" data-file-path="${pth}">${title}</button>
-            <button class="jp-Button toc-chevron" style="display: inline-block;"><i class="fa fa-chevron-down "></i></button>
-        </div>
-        <div style="display: none;">
-        `;
-      const html_cur = html;
-      html = await getSubSection(
-        k.sections,
-        cwd,
-        (level = level + 1),
-        (html = html_cur)
-      );
-      level = level - 1;
-      html += '</div>';
-    } else if (k.file) {
-      await insert_one_file(k.file);
-    } else if (k.url) {
-      html += `<button class="jp-Button toc-button tb-level${level}" style="display:block;"><a class="toc-link tb-level${level}" href="${k.url}" target="_blank" rel="noopener noreferrer" style="display: block;">${k.title}</a></button>`;
-    } else if (k.glob) {
-      const files = await globFiles(`${cwd}${k.glob}`);
-      for (const file of files) {
-        const relative = file.replace(`${cwd}`, '');
-        await insert_one_file(relative);
-      }
-    }
-  }
-  return html;
-}
-
-async function tocToHtml(toc: IToc, cwd: string): Promise<string> {
-  let html = '\n<ul>';
-  if (toc.parts) {
-    for (const chapter of toc.parts) {
-      html += `\n<p class="caption" role="heading"><span class="caption-text"><b>\n${chapter.caption}\n</b></span>\n</p>`;
-      const subISectionHtml = await getSubSection(chapter.chapters, cwd);
-      html += `\n${subISectionHtml}`;
-    }
-  } else {
-    if (toc.chapters) {
-      const subISectionHtml = await getSubSection(toc.chapters, cwd);
-      html += `\n${subISectionHtml}`;
-    }
-  }
-  html += '\n</ul>';
-  return html;
-}
-
 export async function getTOC(cwd: string): Promise<string> {
-  const tocPath = await findTOCinParents(cwd);
+  const tocPath = await findConfigInParents(cwd);
   let configPath = null;
   let configParent = null;
   if (tocPath) {
+    const myst = tocPath.includes("myst")
     const parts = tocPath.split('/');
+
     parts.pop();
     configParent = parts.join('/');
-    const files = await ls(configParent);
-    const configPattern = '_config.yml';
-    for (const value of Object.values(files.content)) {
-      const file = value as IFileMetadata;
-      if (file.path.includes(configPattern)) {
-        configPath = file.path;
-        break;
+    
+    if (!myst) {
+      const files = await ls(configParent);
+      const configPattern = '_config.yml';
+      for (const value of Object.values(files.content)) {
+        const file = value as IFileMetadata;
+        if (file.path.includes(configPattern)) {
+          configPath = file.path;
+          break;
+        }
       }
     }
-  }
 
-  if (
-    tocPath &&
-    configParent !== null &&
-    configParent !== undefined &&
-    configPath
-  ) {
-    try {
-      const tocYamlStr = await getFileContents(tocPath);
-      if (typeof tocYamlStr === 'string') {
-        const tocYaml: unknown = yaml.load(tocYamlStr);
-        const toc = tocYaml as IToc;
-        const config = await getBookConfig(configPath);
-        const toc_html = await tocToHtml(toc, configParent);
-        return `
-          <div class="jbook-toc" data-toc-dir="${configParent}"><p id="toc-title">${config.title}</p>
-          <p id="toc-author">Author: ${config.author}</p>
-          ${toc_html} </div>
-            `;
-      } else {
-        console.error('Error: Misconfigured Jupyter Book _toc.yml.');
+    if (
+      !myst &&
+      configParent !== null &&
+      configParent !== undefined &&
+      configPath
+    ) {
+      try {
+        const tocYamlStr = await getFileContents(tocPath);
+        if (typeof tocYamlStr === 'string') {
+          const tocYaml: unknown = yaml.load(tocYamlStr);
+          const toc = tocYaml as jb1.IToc;
+          const config = await jb1.getBookConfig(configPath);
+          const toc_html = await jb1.tocToHtml(toc, configParent);
+          return `
+            <div class="jbook-toc" data-toc-dir="${configParent}"><p id="toc-title">${config.title}</p>
+            <p id="toc-author">Author: ${config.author}</p>
+            ${toc_html} </div>
+              `;
+        } else {
+          console.error('Error: Misconfigured Jupyter Book _toc.yml.');
+        }
+      } catch (error) {
+        console.error('Error reading or parsing _toc.yml:', error);
       }
-    } catch (error) {
-      console.error('Error reading or parsing _toc.yml:', error);
+    }
+    else if (myst) {
+      try {
+        const mystYAMLStr = await getFileContents(tocPath);
+        if (typeof mystYAMLStr === 'string') {
+          const mystYaml: unknown = yaml.load(mystYAMLStr);
+          const yml = mystYaml as jb2.IMyst;
+          const project = yml.project as jb2.IMystProject;
+          const toc = project.toc as jb2.IMystTOC;
+
+          console.log(project);
+          console.log(toc);
+          const toc_html = await jb2.mystTOCToHtml(project, configParent);
+          console.log(toc_html)
+          // return `
+          //   <div class="jbook-toc" data-toc-dir="${configParent}"><p id="toc-title">${config.title}</p>
+          //   <p id="toc-author">Author: ${config.author}</p>
+          //   ${toc_html} </div>
+          //     `;
+        } else {
+          console.error('Error: Misconfigured Jupyter Book _toc.yml.');
+        }
+      } catch (error) {
+        console.error('Error reading or parsing _toc.yml:', error);
+      }
+
     }
   }
   return `

--- a/src/jbtoc.ts
+++ b/src/jbtoc.ts
@@ -85,7 +85,10 @@ async function findConfigInParents(cwd: string): Promise<string | null> {
   return null;
 }
 
-export async function getFullPath(file_pattern: string, dir_pth: string): Promise<string | null> {
+export async function getFullPath(
+  file_pattern: string,
+  dir_pth: string
+): Promise<string | null> {
   const files = await ls(dir_pth);
   for (const value of Object.values(files.content)) {
     const file = value as FileMetadata;
@@ -181,19 +184,17 @@ export async function formatHtmlForDev(html: string): Promise<string> {
     return html;
   }
 
-  prettierModPromise ??=
-    import('prettier/standalone').catch(err => {
-      prettierModPromise = undefined;
+  prettierModPromise ??= import('prettier/standalone').catch(err => {
+    prettierModPromise = undefined;
+    throw err;
+  });
+
+  htmlPluginPromise ??= import('prettier/plugins/html')
+    .then(m => (m as any).default ?? m)
+    .catch(err => {
+      htmlPluginPromise = undefined;
       throw err;
     });
-
-  htmlPluginPromise ??=
-    import('prettier/plugins/html')
-      .then(m => (m as any).default ?? m)
-      .catch(err => {
-        htmlPluginPromise = undefined;
-        throw err;
-      });
 
   const [prettierMod, htmlPlugin] = await Promise.all([
     prettierModPromise,

--- a/src/jbtoc.ts
+++ b/src/jbtoc.ts
@@ -219,87 +219,19 @@ export async function getTOC(cwd: string): Promise<string> {
           const yml = mystYaml as jb2.IMyst;
           const project = yml.project as jb2.IMystProject;
 
-          let html_top = `<div class="jbook-toc" data-toc-dir="${configParent}">`;
-
-          if (project.title) {
-            html_top += `<p id="toc-title">${project.title}</p>`;
-          }
-          if (project.subtitle) {
-            html_top += `<p id="toc-subtitle">${project.subtitle}</p>`
-          }
-          if (project.authors) {
-            const authors = project.authors;
-            if (authors.length == 1) {
-              html_top += `<p id="toc-author">Author: `
-            } else {
-              html_top += `<p id="toc-author">Authors: `
-            }
-            authors.forEach((author, i) => {
-              if (i < authors.length - 1) {
-                html_top += `${author.name}, `
-              } else {
-                html_top += `${author.name}`
-              }
-            });
-            html_top += `</p>`
-          }
-          if (project.github || project.license || project.doi) {
-            html_top += `<div class=badges>`
-          }
-          if (project.github) {
-            html_top += `
-              <a href="https://github.com/${project.github}" target="_blank" rel="noopener">
-                <img
-                  src="https://img.shields.io/badge/GitHub-5c5c5c?logo=github"
-                  alt="GitHub: ${project.github}"
-                >
-              </a>
-            `
-          }
-          if (project.license) {
-            html_top +=`
-            <a href="https://opensource.org/licenses/${project.license}" target="_blank" rel="noopener">
-              <img
-                src="https://img.shields.io/badge/License-${project.license.replaceAll("-", "_")}--Clause-blue.svg"
-                alt="License: ${project.license}"
-              >
-            </a>
-            `
-          }
-          if (project.doi) {
-            html_top += `
-              <a href="https://doi.org/10.5281/zenodo.${project.doi}" target="_blank" rel="noopener">
-                <img
-                  src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.${project.doi}-blue.svg"
-                  alt="DOI: 10.5281/zenodo.${project.doi}"
-                >
-              </a>
-            `
-          }
-          if (project.github || project.license || project.doi) {
-            html_top += `</div>`
-          }
-          html_top += `<br><hr class=toc-hr>`
-
-          let toc_html = await jb2.mystTOCToHtml(project.toc, configParent);
+          const html_top = await jb2.getHtmlTop(project, configParent);
+          const toc_html = await jb2.mystTOCToHtml(project.toc, configParent);
+          const html_bottom = await jb2.getHtmlBottom(project)
 
           if (project.downloads) {
             {}
           }
 
-          let html_bottom = `<br><hr class=toc-hr>`
-
-          if (project.copyright) {
-            html_bottom += `
-              <p style="padding-left: 15px">Copyright © ${project.copyright}</p>
-            `
-          }
-
           return `
             ${html_top}
             <ul>${toc_html}</ul>
-            ${html_bottom}
             </div>
+            ${html_bottom}
               `;
 
         } else {

--- a/src/jbtoc.ts
+++ b/src/jbtoc.ts
@@ -51,11 +51,11 @@ export async function ls(pth: string): Promise<any> {
 
 export function escapeHtml(str: string): string {
   return str
-    .replaceAll(/&/g, "&amp;")
-    .replaceAll(/</g, "&lt;")
-    .replaceAll(/>/g, "&gt;")
-    .replaceAll(/"/g, "&quot;")
-    .replaceAll(/'/g, "&#39;");
+    .replaceAll(/&/g, '&amp;')
+    .replaceAll(/</g, '&lt;')
+    .replaceAll(/>/g, '&gt;')
+    .replaceAll(/"/g, '&quot;')
+    .replaceAll(/'/g, '&#39;');
 }
 
 async function findConfigInParents(cwd: string): Promise<string | null> {
@@ -169,7 +169,9 @@ export async function globFiles(pattern: string): Promise<string[]> {
   return result;
 }
 
-let prettierModPromise: Promise<typeof import('prettier/standalone')> | undefined;
+let prettierModPromise:
+  | Promise<typeof import('prettier/standalone')>
+  | undefined;
 let htmlPluginPromise: Promise<any> | undefined;
 
 export async function formatHtmlForDev(html: string): Promise<string> {
@@ -182,7 +184,7 @@ export async function formatHtmlForDev(html: string): Promise<string> {
 
   const [prettierMod, htmlPlugin] = await Promise.all([
     prettierModPromise,
-    htmlPluginPromise,
+    htmlPluginPromise
   ]);
 
   const prettier: any = (prettierMod as any).default ?? prettierMod;
@@ -190,7 +192,7 @@ export async function formatHtmlForDev(html: string): Promise<string> {
 
   return await prettier.format(html, {
     parser: 'html',
-    plugins: [parserHtml],
+    plugins: [parserHtml]
   });
 }
 
@@ -277,7 +279,7 @@ export async function getTOC(cwd: string): Promise<string> {
       <p id="toc-author">Please navigate to a Jupyter-Book directory to view its Table of Contents</p>
       `;
   }
-  
+
   if (typeof html === 'string') {
     html = await formatHtmlForDev(html); // no-op in prod
     console.debug(html);

--- a/src/jbtoc.ts
+++ b/src/jbtoc.ts
@@ -7,6 +7,7 @@ import * as jb2 from './jb2';
 
 interface FileMetadata {
   path: string;
+  name: string;
 }
 
 interface Notebook {
@@ -92,19 +93,12 @@ async function findConfigInParents(cwd: string): Promise<string | null> {
   return null;
 }
 
-export async function getFullPath(
-  file_pattern: string,
-  dir_pth: string
-): Promise<string | null> {
-  const files = await ls(dir_pth);
-  for (const value of Object.values(files.content)) {
-    const file = value as FileMetadata;
-    if (file.path.endsWith(file_pattern)) {
-      return file.path;
-    }
+  export function getFullPath(relFile: string, bookRoot: string): string {
+    return path.posix.normalize(
+      (bookRoot.endsWith('/') ? bookRoot : bookRoot + '/') + relFile
+    );
   }
-  return null;
-}
+
 
 function isNotebook(obj: any): obj is Notebook {
   return obj && typeof obj === 'object' && Array.isArray(obj.cells);
@@ -233,8 +227,12 @@ export async function getTOC(cwd: string): Promise<string> {
       const files = await ls(configParent);
       const configPattern = '_config.yml';
       for (const value of Object.values(files.content)) {
+        console.log(value);
+
+
         const file = value as FileMetadata;
-        if (file.path.endsWith(configPattern)) {
+        // if (file.path.endsWith(configPattern)) {
+        if (file.name === configPattern) {
           configPath = file.path;
           break;
         }

--- a/src/jbtoc.ts
+++ b/src/jbtoc.ts
@@ -71,7 +71,7 @@ async function findConfigInParents(cwd: string): Promise<string | null> {
       const files = await ls(pth);
       for (const value of Object.values(files.content)) {
         const file = value as FileMetadata;
-        if (file.path.includes(configPattern)) {
+        if (file.path.endsWith(configPattern)) {
           return file.path;
         }
       }
@@ -90,7 +90,8 @@ export async function getFullPath(file_pattern: string, dir_pth: string) {
   const files = await ls(dir_pth);
   for (const value of Object.values(files.content)) {
     const file = value as FileMetadata;
-    if (file.path.includes(file_pattern)) {
+    if (file.path.endsWith(file_pattern)) {
+      console.log(file.path);
       return file.path;
     }
   }
@@ -178,7 +179,7 @@ export async function getTOC(cwd: string): Promise<string> {
   let configParent = null;
   let html;
   if (tocPath) {
-    const myst = tocPath.includes('myst');
+    const myst = tocPath.endsWith('myst.yml');
     const parts = tocPath.split('/');
 
     parts.pop();
@@ -189,7 +190,7 @@ export async function getTOC(cwd: string): Promise<string> {
       const configPattern = '_config.yml';
       for (const value of Object.values(files.content)) {
         const file = value as FileMetadata;
-        if (file.path.includes(configPattern)) {
+        if (file.path.endsWith(configPattern)) {
           configPath = file.path;
           break;
         }

--- a/src/jbtoc.ts
+++ b/src/jbtoc.ts
@@ -224,10 +224,6 @@ export async function getTOC(cwd: string): Promise<string> {
           const toc_html = await jb2.mystTOCToHtml(project.toc, configParent);
           const html_bottom = await jb2.getHtmlBottom(project);
 
-          if (project.downloads) {
-            {
-            }
-          }
           html = `
             ${html_top}
             <ul>${toc_html}</ul>
@@ -243,7 +239,7 @@ export async function getTOC(cwd: string): Promise<string> {
     }
   }
 
-  if (typeof html == 'string') {
+  if (typeof html === 'string') {
     const formatted_html = await prettier.format(html, {
       parser: 'html',
       plugins: [parserHtml]

--- a/src/jbtoc.ts
+++ b/src/jbtoc.ts
@@ -41,8 +41,7 @@ export async function ls(pth: string): Promise<any> {
 
   try {
     const app = getJupyterAppInstance();
-    const data = await app.serviceManager.contents.get(pth, { content: true });
-    return data;
+    return await app.serviceManager.contents.get(pth, { content: true });
   } catch (error) {
     console.error('Error listing directory contents:', error);
     return null;
@@ -50,14 +49,22 @@ export async function ls(pth: string): Promise<any> {
 }
 
 export function escHtml(str: string): string {
-  return str
+  if (str == null) {
+    return '';
+  }
+  const s = String(str);
+  return s
     .replaceAll(/&/g, '&amp;')
     .replaceAll(/</g, '&lt;')
     .replaceAll(/>/g, '&gt;');
 }
 
 export function escAttr(str: string): string {
-  return escHtml(str).replaceAll(/"/g, '&quot;').replaceAll(/'/g, '&#39;');
+  if (str == null) {
+    return '';
+  }
+  const s = String(str);
+  return escHtml(s).replaceAll(/"/g, '&quot;').replaceAll(/'/g, '&#39;');
 }
 
 async function findConfigInParents(cwd: string): Promise<string | null> {

--- a/src/jbtoc.ts
+++ b/src/jbtoc.ts
@@ -49,11 +49,15 @@ export async function ls(pth: string): Promise<any> {
   }
 }
 
-export function escapeHtml(str: string): string {
+export function escHtml(str: string): string {
   return str
     .replaceAll(/&/g, '&amp;')
     .replaceAll(/</g, '&lt;')
-    .replaceAll(/>/g, '&gt;')
+    .replaceAll(/>/g, '&gt;');
+}
+
+export function escAttr(str: string): string {
+  return escHtml(str)
     .replaceAll(/"/g, '&quot;')
     .replaceAll(/'/g, '&#39;');
 }
@@ -234,8 +238,8 @@ export async function getTOC(cwd: string): Promise<string> {
           const toc_html = await jb1.jBook1TOCToHtml(toc, configParent);
           html = `
           <div class="jbook-toc" data-toc-dir="${configParent}">
-            <p id="toc-title">${escapeHtml(String(config.title))}</p>
-            <p id="toc-author">Author: ${escapeHtml(String(config.author))}</p>
+            <p id="toc-title">${escHtml(String(config.title))}</p>
+            <p id="toc-author">Author: ${escHtml(String(config.author))}</p>
             ${toc_html}
           </div>
           `;
@@ -296,7 +300,7 @@ export async function getTOC(cwd: string): Promise<string> {
         ? (html as any).stack
         : '';
 
-    const escaped = escapeHtml(errMsg + (stack ? `\n\n${stack}` : ''));
+    const escaped = escHtml(errMsg + (stack ? `\n\n${stack}` : ''));
 
     return `
       <div class="jbook-toc-error" style="color: red; font-family: monospace; white-space: pre-wrap; padding: 1em;">

--- a/src/jbtoc.ts
+++ b/src/jbtoc.ts
@@ -219,58 +219,89 @@ export async function getTOC(cwd: string): Promise<string> {
           const yml = mystYaml as jb2.IMyst;
           const project = yml.project as jb2.IMystProject;
 
-          let html = `<div class="jbook-toc" data-toc-dir="${configParent}">`;
+          let html_top = `<div class="jbook-toc" data-toc-dir="${configParent}">`;
 
           if (project.title) {
-            html += `<p id="toc-title">${project.title}</p>`;
+            html_top += `<p id="toc-title">${project.title}</p>`;
           }
           if (project.subtitle) {
-            html += `<p id="toc-subtitle">${project.subtitle}</p>`
-          }
-          if (project.short_title) {
-            {}
-          }
-          if (project.description) {
-            {}
+            html_top += `<p id="toc-subtitle">${project.subtitle}</p>`
           }
           if (project.authors) {
-            // html += `<p id="toc-author">Author: ${project.authors}</p>`
-            {}
+            const authors = project.authors;
+            if (authors.length == 1) {
+              html_top += `<p id="toc-author">Author: `
+            } else {
+              html_top += `<p id="toc-author">Authors: `
+            }
+            authors.forEach((author, i) => {
+              if (i < authors.length - 1) {
+                html_top += `${author.name}, `
+              } else {
+                html_top += `${author.name}`
+              }
+            });
+            html_top += `</p>`
           }
-          if (project.reviewers) {
-            {}
-          }
-          if (project.editors) {
-            {}
-          }
-          if (project.affliliations) {
-            {}
-          }
-          if (project.license) {
-            {}
-          }
-          if (project.copyright) {
-            {}
-          }
-          if (project.doi) {
-            {}
+          if (project.github || project.license || project.doi) {
+            html_top += `<div class=badges>`
           }
           if (project.github) {
-            {}
+            html_top += `
+              <a href="https://github.com/${project.github}" target="_blank" rel="noopener">
+                <img
+                  src="https://img.shields.io/badge/GitHub-5c5c5c?logo=github"
+                  alt="GitHub: ${project.github}"
+                >
+              </a>
+            `
           }
-          if (project.social) {
-            {}
+          if (project.license) {
+            html_top +=`
+            <a href="https://opensource.org/licenses/${project.license}" target="_blank" rel="noopener">
+              <img
+                src="https://img.shields.io/badge/License-${project.license.replaceAll("-", "_")}--Clause-blue.svg"
+                alt="License: ${project.license}"
+              >
+            </a>
+            `
           }
+          if (project.doi) {
+            html_top += `
+              <a href="https://doi.org/10.5281/zenodo.${project.doi}" target="_blank" rel="noopener">
+                <img
+                  src="https://img.shields.io/badge/DOI-10.5281%2Fzenodo.${project.doi}-blue.svg"
+                  alt="DOI: 10.5281/zenodo.${project.doi}"
+                >
+              </a>
+            `
+          }
+          if (project.github || project.license || project.doi) {
+            html_top += `</div>`
+          }
+          html_top += `<br><hr class=toc-hr>`
+
+          let toc_html = await jb2.mystTOCToHtml(project.toc, configParent);
+
           if (project.downloads) {
             {}
           }
 
-          const toc_html = await jb2.mystTOCToHtml(project, configParent);
-          console.log(toc_html)
+          let html_bottom = `<br><hr class=toc-hr>`
+
+          if (project.copyright) {
+            html_bottom += `
+              <p style="padding-left: 15px">Copyright © ${project.copyright}</p>
+            `
+          }
+
           return `
-            ${html}
-            ${toc_html} </div>
+            ${html_top}
+            <ul>${toc_html}</ul>
+            ${html_bottom}
+            </div>
               `;
+
         } else {
           console.error('Error: Misconfigured Jupyter Book _toc.yml.');
         }

--- a/src/jbtoc.ts
+++ b/src/jbtoc.ts
@@ -51,6 +51,16 @@ export async function ls(pth: string): Promise<any> {
   }
 }
 
+export function escapeHtml(str: string): string {
+  console.log(str);
+  return str
+    .replaceAll(/&/g, "&amp;")
+    .replaceAll(/</g, "&lt;")
+    .replaceAll(/>/g, "&gt;")
+    .replaceAll(/"/g, "&quot;")
+    .replaceAll(/'/g, "&#39;");
+}
+
 async function findConfigInParents(cwd: string): Promise<string | null> {
   const configPatterns: string[] = ['myst.yml', '_toc.yml'];
   for (const configPattern of configPatterns) {
@@ -201,8 +211,8 @@ export async function getTOC(cwd: string): Promise<string> {
           const toc_html = await jb1.jBook1TOCToHtml(toc, configParent);
           html = `
           <div class="jbook-toc" data-toc-dir="${configParent}">
-            <p id="toc-title">${config.title}</p>
-            <p id="toc-author">Author: ${config.author}</p>
+            <p id="toc-title">${escapeHtml(String(config.title))}</p>
+            <p id="toc-author">Author: ${escapeHtml(String(config.author))}</p>
             ${toc_html}
           </div>
           `;
@@ -239,19 +249,19 @@ export async function getTOC(cwd: string): Promise<string> {
     }
   }
 
-  if (typeof html === 'string') {
-    const formatted_html = await prettier.format(html, {
-      parser: 'html',
-      plugins: [parserHtml]
-    });
-    console.log(formatted_html);
-    return formatted_html;
-  } else {
-    return `
+  if (typeof html !== 'string') {
+    html = `
       <p id="toc-title">Not a Jupyter-Book</p>
       <p id="toc-author">Could not find a "_toc.yml", "_config.yml", or "myst.yml in or above the current directory:</p>
       <p id="toc-author">${cwd}</p>
       <p id="toc-author">Please navigate to a Jupyter-Book directory to view its Table of Contents</p>
       `;
   }
+
+  html = await prettier.format(html, {
+    parser: 'html',
+    plugins: [parserHtml]
+  });
+  console.debug(html);
+  return html;
 }

--- a/src/jbtoc.ts
+++ b/src/jbtoc.ts
@@ -57,9 +57,7 @@ export function escHtml(str: string): string {
 }
 
 export function escAttr(str: string): string {
-  return escHtml(str)
-    .replaceAll(/"/g, '&quot;')
-    .replaceAll(/'/g, '&#39;');
+  return escHtml(str).replaceAll(/"/g, '&quot;').replaceAll(/'/g, '&#39;');
 }
 
 async function findConfigInParents(cwd: string): Promise<string | null> {

--- a/style/index.css
+++ b/style/index.css
@@ -23,6 +23,18 @@
   color: var(--jp-layout-color3);
 }
 
+.jp-GitHubLink {
+  display: flex;
+  align-items: center;
+  color: var(--jp-ui-font-color1);
+  text-decoration: none;
+  padding-left: 15px;
+}
+
+.jp-GitHubLink:hover {
+  color: var(--jp-content-link-color);
+}
+
 .tb-level1 {
   padding-left: 12px;
 }
@@ -47,6 +59,14 @@
   display: none;
 }
 
+.badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  padding-left: 15px;
+}
+
 #toc-title {
   font-size: var(--jp-ui-font-size2);
   font-weight: bold;
@@ -59,6 +79,18 @@
   font-weight: bold;
   color: var(--jp-ui-font-color2);
   padding-left: 15px;
+}
+
+#toc-subtitle {
+  font-style: italic;
+  padding-left: 15px;
+}
+
+.toc-hr {
+  width: calc(100% - 30px);
+  margin: 0 auto;
+  border: none;
+  border-top: 2px solid var(--jp-layout-color3);
 }
 
 div.lm-Widget[id='@jupyterlab-sidepanel/jupyterbook-toc'] {

--- a/style/index.css
+++ b/style/index.css
@@ -93,6 +93,6 @@
   border-top: 2px solid var(--jp-layout-color3);
 }
 
-div.lm-Widget[id='@jupyterlab-sidepanel/jupyterbook-toc'] {
+div.lm-Widget[id='@jupyterlab-sidepanel/jb-toc'] {
   overflow-y: auto;
 }

--- a/style/index.css
+++ b/style/index.css
@@ -17,7 +17,6 @@
 }
 
 .jp-Button.toc-button.toc-link {
-  /* color: var(--jp-content-link-color); */
   color: #1a73e8;
 }
 

--- a/style/index.css
+++ b/style/index.css
@@ -18,7 +18,7 @@
 
 .jp-Button.toc-button.toc-link {
   /* color: var(--jp-content-link-color); */
-  color: #1a73e8
+  color: #1a73e8;
 }
 
 .jp-Button.toc-chevron:hover {
@@ -107,8 +107,14 @@ div.lm-Widget[id='@jupyterlab-sidepanel/jb-toc'] {
   line-height: 1.4;
 }
 
-.toc-children[hidden] { display: none; }
+.toc-children[hidden] {
+  display: none;
+}
 
-.toc-children { display: block; }
+.toc-children {
+  display: block;
+}
 
-.caption { margin: 0; } 
+.caption {
+  margin: 0;
+}

--- a/style/index.css
+++ b/style/index.css
@@ -3,6 +3,7 @@
 .jp-Button.toc-button {
   color: var(--jp-layout-color4);
   background-color: var(--jp-layout-color1);
+  display: block;
 }
 
 .jp-Button.toc-button:hover {
@@ -15,8 +16,9 @@
   padding-left: 6px;
 }
 
-.toc-link {
-  color: var(--jp-content-link-color);
+.jp-Button.toc-button.toc-link {
+  /* color: var(--jp-content-link-color); */
+  color: #1a73e8
 }
 
 .jp-Button.toc-chevron:hover {
@@ -96,3 +98,17 @@
 div.lm-Widget[id='@jupyterlab-sidepanel/jb-toc'] {
   overflow-y: auto;
 }
+
+.toc-row {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin: 0;
+  line-height: 1.4;
+}
+
+.toc-children[hidden] { display: none; }
+
+.toc-children { display: block; }
+
+.caption { margin: 0; } 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,8 @@
     "rootDir": "src",
     "strict": true,
     "strictNullChecks": true,
-    "target": "ES2018"
+    "target": "es2021",
+    "lib": ["es2021", "dom"]
   },
   "include": ["src/*"]
 }

--- a/ui-tests/package.json
+++ b/ui-tests/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "jupyterlab-jupyterbook-navigation-ui-tests",
+  "name": "jb-toc-ui-tests",
   "version": "1.0.0",
-  "description": "JupyterLab jupyterlab-jupyterbook-navigation Integration Tests",
+  "description": "JupyterLab jb-toc Integration Tests",
   "private": true,
   "scripts": {
     "start": "jupyter lab --config jupyter_server_test_config.py",

--- a/ui-tests/tests/jb_toc.spec.ts
+++ b/ui-tests/tests/jb_toc.spec.ts
@@ -19,7 +19,7 @@ test('should emit an activation console message', async ({ page }) => {
     logs.filter(
       s =>
         s ===
-        'JupyterLab extension jupyterlab-jupyterbook-navigation is activated!'
+        'JupyterLab extension jb-toc is activated!'
     )
   ).toHaveLength(1);
 });

--- a/ui-tests/tests/jb_toc.spec.ts
+++ b/ui-tests/tests/jb_toc.spec.ts
@@ -16,10 +16,6 @@ test('should emit an activation console message', async ({ page }) => {
   await page.goto();
 
   expect(
-    logs.filter(
-      s =>
-        s ===
-        'JupyterLab extension jb-toc is activated!'
-    )
+    logs.filter(s => s === 'JupyterLab extension jb-toc is activated!')
   ).toHaveLength(1);
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -6534,6 +6534,41 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jb-toc@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "jb-toc@workspace:."
+  dependencies:
+    "@jupyterlab/application": ^4.0.0
+    "@jupyterlab/builder": ^4.0.0
+    "@jupyterlab/testutils": ^4.0.0
+    "@types/jest": ^29.2.0
+    "@types/js-yaml": ^4.0.9
+    "@types/json-schema": ^7.0.11
+    "@types/react": ^18.0.26
+    "@types/react-addons-linked-state-mixin": ^0.14.22
+    "@typescript-eslint/eslint-plugin": ^6.1.0
+    "@typescript-eslint/parser": ^6.1.0
+    css-loader: ^6.7.1
+    eslint: ^8.36.0
+    eslint-config-prettier: ^8.8.0
+    eslint-plugin-prettier: ^5.0.0
+    jest: ^29.2.0
+    js-yaml: ^4.1.0
+    npm-run-all: ^4.1.5
+    prettier: ^3.0.0
+    rimraf: ^5.0.1
+    source-map-loader: ^1.0.2
+    style-loader: ^3.3.1
+    stylelint: ^15.10.1
+    stylelint-config-recommended: ^13.0.0
+    stylelint-config-standard: ^34.0.0
+    stylelint-csstree-validator: ^3.0.0
+    stylelint-prettier: ^4.0.0
+    typescript: ~5.0.2
+    yjs: ^13.5.0
+  languageName: unknown
+  linkType: soft
+
 "jest-changed-files@npm:^29.7.0":
   version: 29.7.0
   resolution: "jest-changed-files@npm:29.7.0"
@@ -7201,41 +7236,6 @@ __metadata:
   checksum: 0b40f712900ad0c846681ea2db23b6684b9d5eedf55807b4708c656f5894b63507d0e28ae10aa1bddbea551241035afe62b6df0800fc94c2e2806a7f3adecd7c
   languageName: node
   linkType: hard
-
-"jupyterlab-jupyterbook-navigation@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "jupyterlab-jupyterbook-navigation@workspace:."
-  dependencies:
-    "@jupyterlab/application": ^4.0.0
-    "@jupyterlab/builder": ^4.0.0
-    "@jupyterlab/testutils": ^4.0.0
-    "@types/jest": ^29.2.0
-    "@types/js-yaml": ^4.0.9
-    "@types/json-schema": ^7.0.11
-    "@types/react": ^18.0.26
-    "@types/react-addons-linked-state-mixin": ^0.14.22
-    "@typescript-eslint/eslint-plugin": ^6.1.0
-    "@typescript-eslint/parser": ^6.1.0
-    css-loader: ^6.7.1
-    eslint: ^8.36.0
-    eslint-config-prettier: ^8.8.0
-    eslint-plugin-prettier: ^5.0.0
-    jest: ^29.2.0
-    js-yaml: ^4.1.0
-    npm-run-all: ^4.1.5
-    prettier: ^3.0.0
-    rimraf: ^5.0.1
-    source-map-loader: ^1.0.2
-    style-loader: ^3.3.1
-    stylelint: ^15.10.1
-    stylelint-config-recommended: ^13.0.0
-    stylelint-config-standard: ^34.0.0
-    stylelint-csstree-validator: ^3.0.0
-    stylelint-prettier: ^4.0.0
-    typescript: ~5.0.2
-    yjs: ^13.5.0
-  languageName: unknown
-  linkType: soft
 
 "keyv@npm:^4.5.3":
   version: 4.5.4


### PR DESCRIPTION
- Change extension name from jupyterlab-jupyterbook-navigation to jb-toc
- Add support for Jupyter Book 2 (Jupyter Book 1 still supported)
- Move Jupyter Book 1 specific logic into jb1.ts

## Summary by Sourcery

Add Jupyter Book 2 support and rename the extension to jb-toc, refactor code into dedicated modules for Book 1 and Book 2, update build/CI configurations, tests, styles and documentation accordingly

New Features:
- Add support for Jupyter Book 2 table of contents alongside existing Book 1 support

Enhancements:
- Rename the extension from jupyterlab-jupyterbook-navigation to jb-toc across plugin IDs, package names, paths, CSS selectors and docs
- Refactor core logic by moving Jupyter Book 1 handling into jb1.ts and implementing Jupyter Book 2 logic in jb2.ts with shared utilities in jbtoc.ts
- Introduce Prettier‐powered HTML formatting in development and enhance CSS for GitHub links, badges, subtitles and accessible toggle controls

Build:
- Update pyproject.toml, package.json, tsconfig.json and hatch build targets to use the new extension name and modern TypeScript settings

CI:
- Adjust GitHub Actions workflows to build, test and release the renamed jb-toc extension

Documentation:
- Refresh README, binder environment and documentation to reflect the jb-toc name and JupyterLab version constraints

Tests:
- Rename unit and UI test files to match the new extension name and update console log assertions