### PR TITLE
finally a correct wheel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,20 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: Setup Node 20 + Corepack
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    - name: Yarn config
+      run: |
+        corepack enable
+        yarn --version
+        yarn config set nodeLinker node-modules
+        yarn config set enableImmutableInstalls false
+        yarn config set npmRegistryServer https://registry.npmjs.org
+        rm -rf ~/.yarn/berry/metadata || true
+        yarn cache clean || true
+
     - name: Base Setup
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
@@ -111,7 +125,18 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
-
+    - name: Setup Node 20 + Corepack
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+    - name: Yarn config
+      run: |
+        corepack enable
+        yarn config set nodeLinker node-modules
+        yarn config set enableImmutableInstalls false
+        yarn config set npmRegistryServer https://registry.npmjs.org
+        rm -rf ~/.yarn/berry/metadata || true
+        yarn cache clean || true
     - name: Base Setup
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -14,7 +14,7 @@ dependencies:
   - python >=3.10,<3.13
   - jupyterlab >=4.0.0,<5
   # labextension build dependencies
-  - nodejs >=18,<19
+  - nodejs >=20
   - pip
   - wheel
   # additional packages for demos

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -48,7 +48,8 @@ _("jupyter", "labextension", "list")
 # clone in example v1 and v2 Jupyter Books
 subprocess.run([
     "git", "clone", "--depth", "1",
-    "https://github.com/ASFOpenSARlab/opensarlab_MintPy_Recipe_Book.git"
+    "https://github.com/ASFOpenSARlab/opensarlab_MintPy_Recipe_Book.git",
+    "V1_Jupyter_Book"
 ], check=True)
 
 subprocess.run([

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -31,7 +31,7 @@ def _(*args, **kwargs):
 _(sys.executable, "-m", "pip", "check")
 
 # install the labextension
-_(sys.executable, "-m", "pip", "install", "-e", f"./{JB_TOC}")
+_(sys.executable, "-m", "pip", "install", "-e", {JB_TOC})
 _(sys.executable, "-m", "jupyter", "labextension", "develop", "--overwrite", ".")
 
 # verify the environment the extension didn't break anything

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -31,7 +31,7 @@ def _(*args, **kwargs):
 _(sys.executable, "-m", "pip", "check")
 
 # install the labextension
-_(sys.executable, "-m", "pip", "install", "-e", JB_TOC)
+_(sys.executable, "-m", "pip", "install", "-e", str(JB_TOC))
 _(sys.executable, "-m", "jupyter", "labextension", "develop", "--overwrite", ".")
 
 # verify the environment the extension didn't break anything

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -14,6 +14,7 @@ from pathlib import Path
 
 
 ROOT = Path.cwd()
+JB_TOC_FRONTEND = ROOT / "jb_toc_frontend"
 JB_TOC   = ROOT / "jb_toc"
 
 def _(*args, **kwargs):
@@ -31,6 +32,7 @@ def _(*args, **kwargs):
 _(sys.executable, "-m", "pip", "check")
 
 # install the labextension
+_(sys.executable, "-m", "pip", "install", "-e", str(JB_TOC_FRONTEND))
 _(sys.executable, "-m", "pip", "install", "-e", str(JB_TOC))
 _(sys.executable, "-m", "jupyter", "labextension", "develop", "--overwrite", ".")
 

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -43,6 +43,17 @@ _("jupyter", "server", "extension", "list")
 # initially list installed extensions to determine if there are any surprises
 _("jupyter", "labextension", "list")
 
+# clone in example v1 and v2 Jupyter Books
+subprocess.run([
+    "git", "clone", "--depth", "1",
+    "https://github.com/ASFOpenSARlab/opensarlab_MintPy_Recipe_Book.git"
+], check=True)
+
+subprocess.run([
+    "git", "clone", "--depth", "1",
+    "https://github.com/ASFOpenSARlab/opensarlab-docs.git",
+    "V2_Jupyter_Book"
+], check=True)
 
 print("JupyterLab with jb_toc is ready to run with:\n")
 print("\tjupyter lab\n")

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -31,7 +31,7 @@ def _(*args, **kwargs):
 _(sys.executable, "-m", "pip", "check")
 
 # install the labextension
-_(sys.executable, "-m", "pip", "install", "-e", {JB_TOC})
+_(sys.executable, "-m", "pip", "install", "-e", JB_TOC)
 _(sys.executable, "-m", "jupyter", "labextension", "develop", "--overwrite", ".")
 
 # verify the environment the extension didn't break anything

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -14,6 +14,7 @@ from pathlib import Path
 
 
 ROOT = Path.cwd()
+JB_TOC   = ROOT / "jb_toc"
 
 def _(*args, **kwargs):
     """ Run a command, echoing the args
@@ -30,7 +31,7 @@ def _(*args, **kwargs):
 _(sys.executable, "-m", "pip", "check")
 
 # install the labextension
-_(sys.executable, "-m", "pip", "install", "-e", ".")
+_(sys.executable, "-m", "pip", "install", "-e", f"./{JB_TOC}")
 _(sys.executable, "-m", "jupyter", "labextension", "develop", "--overwrite", ".")
 
 # verify the environment the extension didn't break anything

--- a/jb_toc_frontend/package.json
+++ b/jb_toc_frontend/package.json
@@ -96,6 +96,16 @@
         "access": "public"
     },
     "jupyterlab": {
+        "discovery": {
+            "server": {
+                "managers": [
+                    "pip"
+                ],
+                "base": {
+                    "name": "jb_toc_frontend"
+                }
+            }
+        },
         "extension": true,
         "outputDir": "jb_toc_frontend/labextension"
     },

--- a/jb_toc_frontend/pyproject.toml
+++ b/jb_toc_frontend/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
-    "hatchling>=1.5.0", 
-    "hatch-jupyter-builder>=0.5",
+    "hatchling>=1.27.0", 
+    "hatch-nodejs-version>=0.3.2",
     "jupyterlab>=4.0.0,<5"
     ]
 build-backend = "hatchling.build"
@@ -33,33 +33,44 @@ dependencies = []
 description = "Frontend Jupyter Lab extension providing Jupyter Book Table of Contents in Jupyter Lab"
 keywords = ["jupyter", "jupyterlab", "toc", "jupyter_book"]
 
+[tool.hatch.version]
+source = "nodejs"
+
 [tool.hatch.build.targets.sdist]
 artifacts = ["jb_toc_frontend/labextension"]
 exclude = [".github", "binder"]
 
 [tool.hatch.build.targets.wheel.shared-data]
+"jb_toc_frontend/labextension" = "share/jupyter/labextensions/jb-toc-frontend"
+"jb_toc_frontend/labextension/package.json" = "share/jupyter/labextensions/jb-toc-frontend/package.json"
 "install.json" = "share/jupyter/labextensions/jb-toc-frontend/install.json"
-"labextension" = "share/jupyter/labextensions/jb-toc-frontend"
-
-[tool.hatch.build.targets.wheel]
-packages = ["jb_toc_frontend"]
 
 [tool.hatch.build.hooks.jupyter-builder]
 dependencies = ["hatch-jupyter-builder>=0.5"]
 build-function = "hatch_jupyter_builder.npm_builder"
+ensured-targets = [
+    "jb_toc_frontend/labextension/static/style.js",
+    "jb_toc_frontend/labextension/package.json",
+]
+skip-if-exists = ["jb_toc_frontend/labextension/static/style.js"]
 
 [tool.hatch.build.hooks.jupyter-builder.build-kwargs]
-path = "."
 build_cmd = "build:prod"
 npm = ["jlpm"]
-build_dir = "jb_toc_frontend/labextension"
 
 [tool.hatch.build.hooks.jupyter-builder.editable-build-kwargs]
-path = "."
 build_cmd = "install:extension"
 npm = ["jlpm"]
 source_dir = "src"
 build_dir = "jb_toc_frontend/labextension"
+
+[tool.jupyter-releaser.hooks]
+before-build-npm = [
+    "python -m pip install 'jupyterlab>=4.0.0,<5'",
+    "jlpm",
+    "jlpm build:prod"
+]
+before-build-python = ["jlpm clean:all"]
 
 [tool.check-wheel-contents]
 ignore = ["W002"]

--- a/jb_toc_frontend/pyproject.toml
+++ b/jb_toc_frontend/pyproject.toml
@@ -40,6 +40,9 @@ source = "nodejs"
 artifacts = ["jb_toc_frontend/labextension"]
 exclude = [".github", "binder"]
 
+[tool.hatch.build.targets.wheel]
+exclude = ["jb_toc_frontend/labextension/**"]
+
 [tool.hatch.build.targets.wheel.shared-data]
 "jb_toc_frontend/labextension" = "share/jupyter/labextensions/jb-toc-frontend"
 "jb_toc_frontend/labextension/package.json" = "share/jupyter/labextensions/jb-toc-frontend/package.json"


### PR DESCRIPTION
Wheel now contains the built JS, package.json, and install.json. It can now be installed with pip and results in an enabled frontend extension.

## Summary by Sourcery

Include the built JavaScript extension and necessary metadata in the Python wheel, update build tooling to harness Node.js versioning, and configure CI and binder to use Node 20

New Features:
- Package the compiled frontend assets along with package.json and install.json into the wheel to enable pip installation of the JupyterLab extension

Enhancements:
- Upgrade build system to hatchling>=1.27.0 with nodejs-sourced versioning
- Define sdist and wheel targets to include labextension assets and adjust jupyter-builder hooks for ensured targets and skips
- Introduce jupyter-releaser hooks to run npm and Python build cleanup commands pre-release

CI:
- Add Node 20 + Corepack setup and Yarn configuration steps to GitHub Actions workflows