### PR TITLE
Name cleanup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,7 +89,7 @@ jobs:
     - name: Install both wheels (no deps)
       run: |
         set -eux
-        pip install --no-deps jb_toc_frontend/dist/jb_toc_frontend-*.whl jb_toc/dist/jb_toc-*.whl
+        python -m pip install jb_toc/dist/jb_toc-*.whl
 
     - name: Verify extensions
       run: |
@@ -99,14 +99,14 @@ jobs:
     - name: Upload extension jb_toc_frontend packages
       uses: actions/upload-artifact@v4
       with:
-        name: extension-artifacts
+        name: jb_toc_frontend-artifacts
         path: jb_toc_frontend/dist/jb_toc_frontend*
         if-no-files-found: error
 
     - name: Upload extension jb_toc packages
       uses: actions/upload-artifact@v4
       with:
-        name: extension-artifacts
+        name: jb_toc-artifacts
         path: jb_toc/dist/jb_toc*
         if-no-files-found: error
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,20 +72,42 @@ jobs:
         jupyter labextension list 2>&1 | grep -ie "jb-toc-frontend.*OK"
         python -m jupyterlab.browser_check
 
-    - name: Package the extension
+    - name: Package the jb_toc_frontend extension
       working-directory: jb_toc_frontend
       run: |
         set -eux
-
-        pip install build
+        python -m pip install -U build
         python -m build
-        pip uninstall -y "jb_toc_frontend" jupyterlab
 
-    - name: Upload extension packages
+    - name: Package the jb_toc extension
+      working-directory: jb_toc
+      run: |
+        set -eux
+        python -m pip install -U build
+        python -m build
+
+    - name: Install both wheels (no deps)
+      run: |
+        set -eux
+        pip install --no-deps jb_toc_frontend/dist/jb_toc_frontend-*.whl jb_toc/dist/jb_toc-*.whl
+
+    - name: Verify extensions
+      run: |
+        jupyter server extension list 2>&1 | grep -i "jb_toc.*enabled"
+        jupyter labextension list   2>&1 | grep -i "jb-toc-frontend.*OK"
+
+    - name: Upload extension jb_toc_frontend packages
       uses: actions/upload-artifact@v4
       with:
         name: extension-artifacts
         path: jb_toc_frontend/dist/jb_toc_frontend*
+        if-no-files-found: error
+
+    - name: Upload extension jb_toc packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: extension-artifacts
+        path: jb_toc/dist/jb_toc*
         if-no-files-found: error
 
   test_isolated:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,7 +86,7 @@ jobs:
         python -m pip install -U build
         python -m build
 
-    - name: Install both wheels (no deps)
+    - name: Install both wheels
       run: |
         set -eux
         python -m pip install jb_toc/dist/jb_toc-*.whl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,14 +115,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Install Python
+    - name: Install jb_toc_frontend Python
       uses: actions/setup-python@v5
       with:
         python-version: '3.10'
         architecture: 'x64'
     - uses: actions/download-artifact@v4
       with:
-        name: extension-artifacts
+        name: jb_toc_frontend-artifacts
     - name: Install and Test
       run: |
         set -eux
@@ -134,6 +134,28 @@ jobs:
 
         jupyter labextension list
         jupyter labextension list 2>&1 | grep -ie "jb-toc-frontend.*OK"
+        python -m jupyterlab.browser_check --no-browser-test
+
+    steps:
+    - name: Install jb_toc Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.10'
+        architecture: 'x64'
+    - uses: actions/download-artifact@v4
+      with:
+        name: jb_toc-artifacts
+    - name: Install and Test
+      run: |
+        set -eux
+        # Remove NodeJS, twice to take care of system and locally installed node versions.
+        sudo rm -rf $(which node)
+        sudo rm -rf $(which node)
+
+        pip install "jupyterlab>=4.0.0,<5" jb_toc*.whl
+
+        jupyter labextension list
+        jupyter labextension list 2>&1 | grep -ie "jb-toc.*OK"
         python -m jupyterlab.browser_check --no-browser-test
 
   integration-tests:
@@ -162,11 +184,17 @@ jobs:
     - name: Base Setup
       uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
-    - name: Download extension package
+    - name: Download jb_toc_frontend package
       uses: actions/download-artifact@v4
       with:
-        name: extension-artifacts
+        name: jb_toc_frontend-artifacts
         path: jb_toc_frontend
+
+    - name: Download jb_toc package
+      uses: actions/download-artifact@v4
+      with:
+        name: jb_toc-artifacts
+        path: jb_toc
 
     - name: Install the extension
       working-directory: jb_toc_frontend

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,14 +96,14 @@ jobs:
         jupyter server extension list 2>&1 | grep -i "jb_toc.*enabled"
         jupyter labextension list   2>&1 | grep -i "jb-toc-frontend.*OK"
 
-    - name: Upload extension jb_toc_frontend packages
+    - name: Upload jb_toc_frontend dists
       uses: actions/upload-artifact@v4
       with:
         name: jb_toc_frontend-artifacts
         path: jb_toc_frontend/dist/jb_toc_frontend*
         if-no-files-found: error
 
-    - name: Upload extension jb_toc packages
+    - name: Upload jb_toc dists
       uses: actions/upload-artifact@v4
       with:
         name: jb_toc-artifacts
@@ -113,50 +113,39 @@ jobs:
   test_isolated:
     needs: build
     runs-on: ubuntu-latest
-
     steps:
-    - name: Install jb_toc_frontend Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
-        architecture: 'x64'
-    - uses: actions/download-artifact@v4
-      with:
-        name: jb_toc_frontend-artifacts
-    - name: Install and Test
-      run: |
-        set -eux
-        # Remove NodeJS, twice to take care of system and locally installed node versions.
-        sudo rm -rf $(which node)
-        sudo rm -rf $(which node)
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          architecture: 'x64'
 
-        pip install "jupyterlab>=4.0.0,<5" jb_toc_frontend*.whl
+      - name: Download frontend artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: jb_toc_frontend-artifacts
+          path: wheels
 
-        jupyter labextension list
-        jupyter labextension list 2>&1 | grep -ie "jb-toc-frontend.*OK"
-        python -m jupyterlab.browser_check --no-browser-test
+      - name: Download backend artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: jb_toc-artifacts
+          path: wheels
 
-    steps:
-    - name: Install jb_toc Python
-      uses: actions/setup-python@v5
-      with:
-        python-version: '3.10'
-        architecture: 'x64'
-    - uses: actions/download-artifact@v4
-      with:
-        name: jb_toc-artifacts
-    - name: Install and Test
-      run: |
-        set -eux
-        # Remove NodeJS, twice to take care of system and locally installed node versions.
-        sudo rm -rf $(which node)
-        sudo rm -rf $(which node)
+      - name: Install and test both
+        run: |
+          set -eux
+          # Make sure we don't accidentally use Node during browser_check
+          sudo rm -f "$(which node)" || true
+          sudo rm -f "$(which node)" || true
 
-        pip install "jupyterlab>=4.0.0,<5" jb_toc*.whl
+          pip install "jupyterlab>=4.0.0,<5" wheels/jb_toc_frontend-*.whl wheels/jb_toc-*.whl
 
-        jupyter labextension list
-        jupyter labextension list 2>&1 | grep -ie "jb-toc.*OK"
-        python -m jupyterlab.browser_check --no-browser-test
+          jupyter labextension list
+          jupyter labextension list 2>&1 | grep -ie "jb-toc-frontend.*OK"
+          jupyter server extension list 2>&1 | grep -ie "jb_toc.*enabled"
+
+          python -m jupyterlab.browser_check --no-browser-test
 
   integration-tests:
     name: Integration tests

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -20,9 +20,6 @@ jobs:
   prep_release:
     runs-on: ubuntu-latest
     environment: publishing
-    env:
-      PIP_NO_INDEX: "1"
-      PIP_FIND_LINKS: "dist"
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
@@ -43,6 +40,9 @@ jobs:
           branch: ${{ github.event.inputs.branch }}
           release_url: ${{ github.event.inputs.release_url }}
           steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
+        env:
+          PIP_NO_INDEX: "1"
+          PIP_FIND_LINKS: "file://${{ github.workspace }}/dist"
 
       - name: "** Next Step **"
         run: |

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -12,6 +12,9 @@ on:
         description: "Use PRs with activity since the last stable git tag"
         required: false
         type: boolean
+      steps_to_skip:
+        description: "Comma separated list of steps to skip"
+        required: false
 
 jobs:
   prep_release:
@@ -29,11 +32,14 @@ jobs:
           since: ${{ github.event.inputs.since }}
           since_last_stable: ${{ github.event.inputs.since_last_stable }}
 
-      - name: Build Release (attach artifacts to draft release)
-        uses: jupyter-server/jupyter_releaser/.github/actions/build-release@v2
+      - name: Populate Release
+        id: populate
+        uses: jupyter-server/jupyter_releaser/.github/actions/populate-release@v2
         with:
           token: ${{ secrets.PUBLISH_GITHUB_PAT }}
-          release_url: ${{ steps.prep.outputs.release_url }}
+          branch: ${{ github.event.inputs.branch }}
+          release_url: ${{ github.event.inputs.release_url }}
+          steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
 
       - name: "** Next Step **"
         run: |
@@ -42,4 +48,4 @@ jobs:
           echo "${{ steps.prep.outputs.release_url }}"
           echo ""
           echo "Trigger the 'Publish Release' workflow with:"
-          echo "  release_url=${{ steps.prep.outputs.release_url }}"      
+          echo "  release_url=${{ steps.populate.outputs.release_url }}"      

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -36,7 +36,7 @@ jobs:
           token: ${{ secrets.PUBLISH_GITHUB_PAT }}
           branch: ${{ github.event.inputs.branch }}
           release_url: ${{ github.event.inputs.release_url }}
-          steps_to_skip: check-python
+          steps_to_skip: tag-release,check-python
 
       - name: Smoke test wheels (no deps)
         run: |

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -38,14 +38,14 @@ jobs:
           release_url: ${{ github.event.inputs.release_url }}
           steps_to_skip: check-python
 
-      - name: Install jupyter-releaser
-        run: python -m pip install -U jupyter-releaser
-        
-      - name: Check Python dists (no deps)
+      - name: Smoke test wheels (no deps)
         run: |
-          jupyter-releaser check-python
-        env:
-          PIP_NO_DEPS: "1"
+          python -m venv .venv
+          . .venv/bin/activate
+          python -m pip install -U pip
+          pip install --no-deps dist/jb_toc_frontend-*.whl
+          pip install --no-deps dist/jb_toc-*.whl
+          python -c "import jb_toc, importlib; importlib.import_module('jb_toc_frontend'); print('import OK:', jb_toc.__version__)"
 
       - name: "** Next Step **"
         run: |

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 
       - name: Prep Release
-        id: prep-release
+        id: prep
         uses: jupyter-server/jupyter_releaser/.github/actions/prep-release@v2
         with:
           token: ${{ secrets.PUBLISH_GITHUB_PAT }}

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -20,6 +20,9 @@ jobs:
   prep_release:
     runs-on: ubuntu-latest
     environment: publishing
+    env:
+      PIP_NO_INDEX: "1"
+      PIP_FIND_LINKS: "dist"
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
 

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -12,9 +12,6 @@ on:
         description: "Use PRs with activity since the last stable git tag"
         required: false
         type: boolean
-      steps_to_skip:
-        description: "Comma separated list of steps to skip"
-        required: false
 
 jobs:
   prep_release:
@@ -39,10 +36,16 @@ jobs:
           token: ${{ secrets.PUBLISH_GITHUB_PAT }}
           branch: ${{ github.event.inputs.branch }}
           release_url: ${{ github.event.inputs.release_url }}
-          steps_to_skip: ${{ github.event.inputs.steps_to_skip }}
+          steps_to_skip: check-python
+
+      - name: Install jupyter-releaser
+        run: python -m pip install -U jupyter-releaser
+        
+      - name: Check Python dists (no deps)
+        run: |
+          jupyter-releaser check-python
         env:
-          PIP_NO_INDEX: "1"
-          PIP_FIND_LINKS: "file://${{ github.workspace }}/dist"
+          PIP_NO_DEPS: "1"
 
       - name: "** Next Step **"
         run: |

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -38,15 +38,6 @@ jobs:
           release_url: ${{ github.event.inputs.release_url }}
           steps_to_skip: tag-release,check-python
 
-      - name: Smoke test wheels (no deps)
-        run: |
-          python -m venv .venv
-          . .venv/bin/activate
-          python -m pip install -U pip
-          pip install --no-deps dist/jb_toc_frontend-*.whl
-          pip install --no-deps dist/jb_toc-*.whl
-          python -c "import jb_toc, importlib; importlib.import_module('jb_toc_frontend'); print('import OK:', jb_toc.__version__)"
-
       - name: "** Next Step **"
         run: |
           echo "Draft Release built successfully!"

--- a/.github/workflows/prep-release.yml
+++ b/.github/workflows/prep-release.yml
@@ -29,6 +29,17 @@ jobs:
           since: ${{ github.event.inputs.since }}
           since_last_stable: ${{ github.event.inputs.since_last_stable }}
 
+      - name: Build Release (attach artifacts to draft release)
+        uses: jupyter-server/jupyter_releaser/.github/actions/build-release@v2
+        with:
+          token: ${{ secrets.PUBLISH_GITHUB_PAT }}
+          release_url: ${{ steps.prep.outputs.release_url }}
+
       - name: "** Next Step **"
         run: |
-          echo "Optional): Review Draft Release: ${{ steps.prep-release.outputs.release_url }}"
+          echo "Draft Release built successfully!"
+          echo "Review artifacts and changelog here:"
+          echo "${{ steps.prep.outputs.release_url }}"
+          echo ""
+          echo "Trigger the 'Publish Release' workflow with:"
+          echo "  release_url=${{ steps.prep.outputs.release_url }}"      

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 2.0.0
+
+No merged PRs
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 1.0.4
 
 ([Full Changelog](https://github.com/ASFOpenSARlab/jupyterlab-jupyterbook-navigation/compare/v1.0.3...318e0ab2350900daade474de8ca1296126362943))
@@ -15,8 +21,6 @@
 ([GitHub contributors page for this release](https://github.com/ASFOpenSARlab/jupyterlab-jupyterbook-navigation/graphs/contributors?from=2025-03-22&to=2025-03-22&type=c))
 
 [@Alex-Lewandowski](https://github.com/search?q=repo%3AASFOpenSARlab%2Fjupyterlab-jupyterbook-navigation+involves%3AAlex-Lewandowski+updated%3A2025-03-22..2025-03-22&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 1.0.3
 

--- a/jb_toc/package.json
+++ b/jb_toc/package.json
@@ -1,4 +1,0 @@
-{
-  "name": "jb_toc",
-  "version": "0.0.0"
-}

--- a/jb_toc/pyproject.toml
+++ b/jb_toc/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 dependencies = [
     "jupyter-server>=2.0.0",
     "jupyter-server-globbing",
-    "jb_toc_frontend==0.0.0",
+    "jb-toc-frontend==0.0.0",
     ]
 description = "Server extension providing /jbtoc/titles for jb_toc_frontend, if Jupyter Server is available."
 keywords = ["jupyter", "jupyterlab", "toc", "jupyter_book"]

--- a/jb_toc/pyproject.toml
+++ b/jb_toc/pyproject.toml
@@ -10,7 +10,7 @@ requires-python = ">=3.10"
 
 # This version is synced with jb-toc/pyproject.toml during release.
 # Do not manually set.
-version = "0.0.0"
+version = "2.0.0"
 
 classifiers = [
     "Framework :: Jupyter",
@@ -29,7 +29,7 @@ classifiers = [
 dependencies = [
     "jupyter-server>=2.0.0",
     "jupyter-server-globbing",
-    "jb-toc-frontend==0.0.0",
+    "jb-toc-frontend==2.0.0",
     ]
 description = "Server extension providing /jbtoc/titles for jb_toc_frontend, if Jupyter Server is available."
 keywords = ["jupyter", "jupyterlab", "toc", "jupyter_book"]

--- a/jb_toc/pyproject.toml
+++ b/jb_toc/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling>=1.5.0"]
 build-backend = "hatchling.build"
 
 [project]
-name = "jb_toc"
+name = "jb-toc"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.10"

--- a/jb_toc_frontend/package.json
+++ b/jb_toc_frontend/package.json
@@ -1,6 +1,6 @@
 {
     "name": "jb-toc-frontend",
-    "version": "0.0.0",
+    "version": "2.0.0",
     "description": "A JupyterLab extension that mimics jupyter-book chapter navigation on an un-built, cloned jupyter book in JupyterLab.",
     "keywords": [
         "jupyter",

--- a/jb_toc_frontend/pyproject.toml
+++ b/jb_toc_frontend/pyproject.toml
@@ -11,7 +11,7 @@ name = "jb-toc-frontend"
 
 # This version is synced with jb-toc/pyproject.toml during release.
 # Do not manually set.
-version = "0.0.0"
+version = "2.0.0"
 
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/jb_toc_frontend/pyproject.toml
+++ b/jb_toc_frontend/pyproject.toml
@@ -7,7 +7,7 @@ requires = [
 build-backend = "hatchling.build"
 
 [project]
-name = "jb_toc_frontend"
+name = "jb-toc-frontend"
 
 # This version is synced with jb-toc/pyproject.toml during release.
 # Do not manually set.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ version = "2.0.0"
 [tool.jupyter-releaser.options]
 version_cmd  = 'bash -lc "python \"$(git rev-parse --show-toplevel)/scripts/sync_version.py\" --version $0"'
 npm_command = 'bash -lc "jlpm --cwd \"$(git rev-parse --show-toplevel)/jb_toc_frontend\" install --immutable && jlpm --cwd \"$(git rev-parse --show-toplevel)/jb_toc_frontend\" build:prod"'
+npm_package_dirs = ["jb_toc_frontend"]
 python_packages = ["jb_toc_frontend", "jb_toc"]
 changelog_path = "CHANGELOG.md"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,9 +38,3 @@ before-bump-version = [
   'bash -lc "pwd"',
   'bash -lc "python \"$(git rev-parse --show-toplevel)/scripts/sync_version.py\""'
 ]
-after-build-python = [
-  # jb_toc_frontend is a dependency of jb_toc (with version parity), so we install from 
-  # local wheels during GitHub Actions
-
-  "python scripts/install_local_wheels.py"
-]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling>=1.5.0"]
 build-backend = "hatchling.build"
 
 [project]
-name = "jb_toc_frontend"
+name = "jb-toc-frontend"
 
 # Source of truth for both jb_toc and jb_toc_frontend packages: 
 # All pyproject.toml and package.json files will be synched to this version.

--- a/scripts/sync_version.py
+++ b/scripts/sync_version.py
@@ -12,7 +12,7 @@ SEMVER = re.compile(
 
 PROJECT_TABLE_RE = re.compile(r'(?ms)^\[project\]\s*(?P<body>.*?)(?=^\[[^\]]+\]|\Z)')
 VERSION_LINE_RE = re.compile(r'(?m)^\s*version\s*=\s*([\'"])(?P<ver>.*?)(\1)\s*$')
-FRONTEND_DEP_RE = re.compile(r'(?m)^[ \t]*"jb_toc_frontend\s*==\s*(?P<ver>[^"]+)"[ \t]*,?$')
+FRONTEND_DEP_RE = re.compile(r'(?m)^[ \t]*"jb-toc-frontend\s*==\s*(?P<ver>[^"]+)"[ \t]*,?$')
 
 def npm_to_pep440(v: str) -> str:
     m = SEMVER.match(v or "")
@@ -71,11 +71,11 @@ def ensure_project_dep(pyproj_text: str, pep440_version: str) -> str:
     body = m.group('body')
 
     if FRONTEND_DEP_RE.search(body):
-        body = FRONTEND_DEP_RE.sub(f'    "jb_toc_frontend=={pep440_version}",', body, count=1)
+        body = FRONTEND_DEP_RE.sub(f'    "jb-toc-frontend=={pep440_version}",', body, count=1)
     else:
         if body and not body.startswith("\n"):
             body = "\n" + body
-        body = f'\n    "jb_toc_frontend=={pep440_version}"\n{body}'
+        body = f'\n    "jb-toc-frontend=={pep440_version}"\n{body}'
 
     new_project_block = f"[project]\n{body}"
     return pyproj_text[:start] + new_project_block + pyproj_text[end:]
@@ -121,7 +121,6 @@ def main():
     ]
     package_json_paths = [
         root / "jb_toc_frontend/package.json",
-        root / "jb_toc/package.json",
     ]
 
     data = root_pyproject.read_text(encoding="utf-8")


### PR DESCRIPTION
- Update package names in pyproject.toml files
  - jb_toc -> jb-toc
  - jb_toc_frontend -> jb-toc-frontend
- Update package names in sync script
- Remove unnecessary package.json for backend package

## Summary by Sourcery

Rename jb_toc and jb_toc_frontend packages to use hyphenated names, update the version sync script to match, and remove the obsolete backend package.json file.

Enhancements:
- Standardize package names to hyphen-separated format (jb-toc, jb-toc-frontend) in pyproject.toml and dependency listings
- Update sync_version.py regex and substitutions to reference the renamed frontend package for version syncing

Chores:
- Remove the unnecessary package.json file from the backend package