### PR TITLE
Add repository URLs to project metadata

### DIFF
--- a/jb_toc/pyproject.toml
+++ b/jb_toc/pyproject.toml
@@ -34,6 +34,11 @@ dependencies = [
 description = "Server extension providing /jbtoc/titles for jb-toc-frontend, if Jupyter Server is available."
 keywords = ["jupyter", "jupyterlab", "toc", "jupyter_book"]
 
+[project.urls]
+Homepage = "https://github.com/ASFOpenSARlab/jb-toc"
+Repository = "https://github.com/ASFOpenSARlab/jb-toc"
+Issues = "https://github.com/ASFOpenSARlab/jb-toc/issues"
+
 [project.optional-dependencies]
 test = [
     "coverage",

--- a/jb_toc_frontend/pyproject.toml
+++ b/jb_toc_frontend/pyproject.toml
@@ -36,6 +36,11 @@ dependencies = []
 description = "Frontend Jupyter Lab extension providing Jupyter Book Table of Contents in Jupyter Lab"
 keywords = ["jupyter", "jupyterlab", "toc", "jupyter_book"]
 
+[project.urls]
+Homepage = "https://github.com/ASFOpenSARlab/jb-toc"
+Repository = "https://github.com/ASFOpenSARlab/jb-toc"
+Issues = "https://github.com/ASFOpenSARlab/jb-toc/issues"
+
 [tool.hatch.version]
 source = "nodejs"
 


### PR DESCRIPTION
## Summary
- add missing [project.urls] metadata so both packages link back to ASFOpenSARlab/jb-toc
- this lets PyPI to show the right repo/issue links and catalogs like the community [JupyterLab Marketplace](labextensions.dev/extensions/jb-toc) able to display this data

## Testing
- not run (metadata only)
